### PR TITLE
avoid stale isMuted state in mic event handler

### DIFF
--- a/examples/next-app/components/ExampleComponent.tsx
+++ b/examples/next-app/components/ExampleComponent.tsx
@@ -3,7 +3,7 @@
 import { useAssistant } from '@humeai/assistant-react';
 
 export const ExampleComponent = ({ apiKey }: { apiKey: string }) => {
-  const { isPlaying, readyState } = useAssistant({
+  const { isPlaying, readyState, mute, unmute, isMuted } = useAssistant({
     apiKey,
     hostname: 'api.hume.ai',
   });
@@ -13,6 +13,14 @@ export const ExampleComponent = ({ apiKey }: { apiKey: string }) => {
       <div className={'font-light'}>
         <div>Playing: {isPlaying ? 'true' : 'false'}</div>
         <div>Ready State: {readyState}</div>
+
+        <div className="flex gap-4">
+          {isMuted ? (
+            <button onClick={() => unmute()}>Unmute</button>
+          ) : (
+            <button onClick={() => mute()}>Mute</button>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/packages/react/src/lib/useAssistant.ts
+++ b/packages/react/src/lib/useAssistant.ts
@@ -28,6 +28,7 @@ export const useAssistant = (props: Parameters<typeof createConfig>[0]) => {
     isPlaying: player.isPlaying,
     messages: client.messages,
     readyState: client.readyState,
+    isMuted: mic.isMuted,
     mute: mic.mute,
     unmute: mic.unmute,
   };


### PR DESCRIPTION
* introduces `isMutedRef`, which addresses the issue where the microphone event listener was closing over a stale `isMuted` value
* isMuted state variable is still needed so that consumers of the react hook can still accurately know if the mic is muted (can't use isMutedRef for that scenario because refs don't trigger rerenders)