### PR TITLE
switch from one hook to context

### DIFF
--- a/apps/assistant-renderer/src/App.tsx
+++ b/apps/assistant-renderer/src/App.tsx
@@ -6,6 +6,7 @@ import { MessageListener } from '@/components/MessageListener';
 import { useConfigStore } from '@/store/config';
 import { Frame } from './components/Frame';
 import { AnimatePresence } from 'framer-motion';
+import { AssistantProvider } from '@humeai/assistant-react';
 
 function App() {
   const setApiKey = useConfigStore((store) => store.setApiKey);
@@ -23,7 +24,9 @@ function App() {
         {apiKey ? (
           <Frame>
             <AnimatePresence mode={'wait'}>
-              <Views apiKey={apiKey} />
+              <AssistantProvider apiKey={apiKey}>
+                <Views />
+              </AssistantProvider>
             </AnimatePresence>
           </Frame>
         ) : null}

--- a/apps/assistant-renderer/src/views/Views.tsx
+++ b/apps/assistant-renderer/src/views/Views.tsx
@@ -8,16 +8,14 @@ import {
   AssistantAnimationState,
 } from '@/components/AssistantAnimation';
 
-export type ViewsProps = {
-  apiKey: string;
-};
+export type ViewsProps = Record<never, never>;
 
-export const Views: FC<ViewsProps> = ({ apiKey }) => {
+export const Views: FC<ViewsProps> = () => {
   const layoutState = useLayoutStore((store) => store.state);
   const open = useLayoutStore((store) => store.open);
   const close = useLayoutStore((store) => store.close);
 
-  const { connect, disconnect, fft } = useAssistant({ apiKey });
+  const { connect, disconnect, fft } = useAssistant();
 
   if (layoutState === LayoutState.CLOSED) {
     return (

--- a/examples/next-app/app/page.tsx
+++ b/examples/next-app/app/page.tsx
@@ -1,3 +1,5 @@
+import { AssistantProvider } from '@humeai/assistant-react';
+
 import { ExampleComponent } from '@/components/ExampleComponent';
 
 export default function Home() {
@@ -8,7 +10,9 @@ export default function Home() {
       <h1 className={'font-medium'}>Hume Assistant Example Component</h1>
 
       {apiKey ? (
-        <ExampleComponent apiKey={apiKey} />
+        <AssistantProvider apiKey={apiKey} hostname={'api.hume.ai'}>
+          <ExampleComponent />
+        </AssistantProvider>
       ) : (
         <div>Missing API Key</div>
       )}

--- a/examples/next-app/components/ExampleComponent.tsx
+++ b/examples/next-app/components/ExampleComponent.tsx
@@ -10,7 +10,7 @@ function getTop3Expressions(
   return [...expressionOutputs].sort((a, b) => b.score - a.score).slice(0, 3);
 }
 
-export const ExampleComponent = ({ apiKey }: { apiKey: string }) => {
+export const ExampleComponent = () => {
   const {
     connect,
     disconnect,
@@ -22,10 +22,7 @@ export const ExampleComponent = ({ apiKey }: { apiKey: string }) => {
     readyState,
     unmute,
     messages,
-  } = useAssistant({
-    apiKey,
-    hostname: 'api.hume.ai',
-  });
+  } = useAssistant();
 
   const normalizedFft = useMemo(() => {
     const max = 2.5;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,7 +1,7 @@
 export * from './lib/EmbeddedAssistant';
 export * from './lib/useSoundPlayer';
 export * from './lib/useMicrophone';
-export * from './lib/useAssistant';
+export * from './lib/Assistant';
 export * from './lib/useAssistantClient';
 
 export {

--- a/packages/react/src/lib/useAssistantClient.test.ts
+++ b/packages/react/src/lib/useAssistantClient.test.ts
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
-import { ReadyState, useAssistantClient } from './useAssistantClient';
+import { AssistantReadyState, useAssistantClient } from './useAssistantClient';
 
 describe('useAssistantClient', () => {
   it('creates a client with the given config', () => {
@@ -11,6 +11,6 @@ describe('useAssistantClient', () => {
       }),
     );
 
-    expect(hook.result.current.readyState).toBe(ReadyState.IDLE);
+    expect(hook.result.current.readyState).toBe(AssistantReadyState.IDLE);
   });
 });

--- a/packages/react/src/lib/useAssistantClient.ts
+++ b/packages/react/src/lib/useAssistantClient.ts
@@ -2,7 +2,7 @@ import type { Config, TranscriptMessage } from '@humeai/assistant';
 import { AssistantClient } from '@humeai/assistant';
 import { useCallback, useRef, useState } from 'react';
 
-export enum ReadyState {
+export enum AssistantReadyState {
   IDLE = 'idle',
   CONNECTING = 'connecting',
   OPEN = 'open',
@@ -15,7 +15,9 @@ export const useAssistantClient = (props: {
 }) => {
   const client = useRef<AssistantClient | null>(null);
 
-  const [readyState, setReadyState] = useState<ReadyState>(ReadyState.IDLE);
+  const [readyState, setReadyState] = useState<AssistantReadyState>(
+    AssistantReadyState.IDLE,
+  );
   const [messages, setMessages] = useState<TranscriptMessage[]>([]);
 
   const onAudioMessage = useRef<
@@ -28,8 +30,8 @@ export const useAssistantClient = (props: {
       client.current = AssistantClient.create(config);
 
       client.current.on('open', () => {
-        setReadyState(ReadyState.OPEN);
-        resolve(ReadyState.OPEN);
+        setReadyState(AssistantReadyState.OPEN);
+        resolve(AssistantReadyState.OPEN);
       });
 
       client.current.on('message', (message) => {
@@ -48,7 +50,7 @@ export const useAssistantClient = (props: {
       });
 
       client.current.on('close', () => {
-        setReadyState(ReadyState.CLOSED);
+        setReadyState(AssistantReadyState.CLOSED);
       });
 
       client.current.on('error', (e) => {
@@ -57,7 +59,7 @@ export const useAssistantClient = (props: {
         reject(e);
       });
 
-      setReadyState(ReadyState.CONNECTING);
+      setReadyState(AssistantReadyState.CONNECTING);
 
       client.current.connect();
     });
@@ -65,7 +67,7 @@ export const useAssistantClient = (props: {
 
   const disconnect = () => {
     setMessages([]);
-    setReadyState(ReadyState.IDLE);
+    setReadyState(AssistantReadyState.IDLE);
     client.current?.disconnect();
   };
 


### PR DESCRIPTION
changes api from 

```tsx
const { connect } = useAssistant({ apiKey: 'abc' })
```

to 

```tsx
const { connect } = useAssistant()
```

and global config objects are passed to `<AssistantProvider/>` instead

should reduce how much prop drilling is required to use hook in an example app

also makes it less likely to accidentally create several instances of assistant web socket through app if hook is called more than once