### PR TITLE
add last message

### DIFF
--- a/packages/react/src/lib/Assistant.tsx
+++ b/packages/react/src/lib/Assistant.tsx
@@ -35,6 +35,8 @@ export type AssistantContextType = {
   isMuted: boolean;
   isPlaying: boolean;
   messages: TranscriptMessage[];
+  lastAssistantMessage: TranscriptMessage | null;
+  lastUserMessage: TranscriptMessage | null;
   mute: () => void;
   unmute: () => void;
   readyState: AssistantReadyState;
@@ -178,6 +180,8 @@ export const AssistantProvider: FC<AssistantProviderProps> = ({
       isMuted: mic.isMuted,
       isPlaying: player.isPlaying,
       messages: client.messages,
+      lastAssistantMessage: client.lastAssistantMessage,
+      lastUserMessage: client.lastUserMessage,
       mute: mic.mute,
       readyState: client.readyState,
       status,
@@ -185,6 +189,8 @@ export const AssistantProvider: FC<AssistantProviderProps> = ({
     }),
     [
       client.messages,
+      client.lastAssistantMessage,
+      client.lastUserMessage,
       client.readyState,
       connect,
       disconnect,

--- a/packages/react/src/lib/useAssistantClient.ts
+++ b/packages/react/src/lib/useAssistantClient.ts
@@ -20,6 +20,11 @@ export const useAssistantClient = (props: {
     AssistantReadyState.IDLE,
   );
   const [messages, setMessages] = useState<TranscriptMessage[]>([]);
+  const [lastAssistantMessage, setLastAssistantMessage] =
+    useState<TranscriptMessage | null>(null);
+  const [lastUserMessage, setLastUser] = useState<TranscriptMessage | null>(
+    null,
+  );
 
   const onAudioMessage = useRef<typeof props.onAudioMessage>(
     props.onAudioMessage,
@@ -44,6 +49,14 @@ export const useAssistantClient = (props: {
         client.current.on('message', (message) => {
           if (message.type === 'audio') {
             onAudioMessage.current?.(message.data);
+          }
+
+          if (message.type === 'assistant_message') {
+            setLastAssistantMessage(message);
+          }
+
+          if (message.type === 'user_message') {
+            setLastUser(message);
           }
 
           if (
@@ -88,6 +101,8 @@ export const useAssistantClient = (props: {
   return {
     readyState,
     messages,
+    lastAssistantMessage,
+    lastUserMessage,
     sendAudio,
     connect,
     disconnect,


### PR DESCRIPTION
adds `lastUserMessage` and `lastAssistantMessage` to hook

i'm pushing these as independent `useState` values, my thinking is that it's a little more performant than doing a `find()` on each update to messages state object as a derived value.