### PR TITLE
fix microphone muting

### DIFF
--- a/packages/react/src/lib/useMicrophone.ts
+++ b/packages/react/src/lib/useMicrophone.ts
@@ -23,8 +23,6 @@ export type MicrophoneProps = {
 
 export const useMicrophone = (props: MicrophoneProps) => {
   const { streamRef, onAudioCaptured, onError } = props;
-  const isMutedRef = useRef(false);
-
   const [isMuted, setIsMuted] = useState(false);
   const [fft, setFft] = useState<number[]>(generateEmptyFft());
   const currentAnalyzer = useRef<Meyda.MeydaAnalyzer | null>(null);
@@ -39,10 +37,6 @@ export const useMicrophone = (props: MicrophoneProps) => {
 
   const dataHandler = useCallback((event: IBlobEvent) => {
     const blob = event.data;
-
-    if (isMutedRef.current) {
-      return;
-    }
 
     blob
       .arrayBuffer()
@@ -115,8 +109,9 @@ export const useMicrophone = (props: MicrophoneProps) => {
       currentAnalyzer.current.stop();
       setFft(generateEmptyFft());
     }
-
-    isMutedRef.current = true;
+    streamRef.current?.getTracks().forEach((track) => {
+      track.enabled = false;
+    });
     setIsMuted(true);
   }, []);
 
@@ -124,7 +119,10 @@ export const useMicrophone = (props: MicrophoneProps) => {
     if (currentAnalyzer.current) {
       currentAnalyzer.current.start();
     }
-    isMutedRef.current = false;
+    streamRef.current?.getTracks().forEach((track) => {
+      track.enabled = true;
+    });
+
     setIsMuted(false);
   }, []);
 


### PR DESCRIPTION
this PR addresses the issue where the backend stops sending responses if the user mutes their mic immediately after speaking. the bug happens because the backend expects a constant stream of audio - if audio chunks stop being sent, processing will be paused. therefore, the client need to continue sending audio blobs even when the microphone is muted. 