### PR TITLE
Center intro screen

### DIFF
--- a/apps/voice-embed-renderer/src/components/ConversationFrame/index.tsx
+++ b/apps/voice-embed-renderer/src/components/ConversationFrame/index.tsx
@@ -47,7 +47,9 @@ export const ConversationFrame: FC<ConversationFrameProps> = ({
         {children}
       </motion.div>
 
-      <motion.div className={'flex shrink-0 grow-0 items-center gap-2 p-2'}>
+      <motion.div
+        className={'z-10 flex shrink-0 grow-0 items-center gap-2 p-2'}
+      >
         {status.value === 'connected' && (
           <Tooltip.Provider delayDuration={400} skipDelayDuration={500}>
             <Tooltip.Root>

--- a/apps/voice-embed-renderer/src/components/IntroScreen/index.tsx
+++ b/apps/voice-embed-renderer/src/components/IntroScreen/index.tsx
@@ -4,12 +4,12 @@ import { motion } from 'framer-motion';
 export const IntroScreen = ({ onConnect }: { onConnect: () => void }) => {
   return (
     <motion.div
-      className="flex flex-col items-center gap-8 px-4"
+      className="absolute inset-0 flex flex-col items-center justify-center gap-8 px-12"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1, translateY: -4 }}
       transition={{ duration: 2 }}
     >
-      <h2 className="mt-6 text-center text-3xl">
+      <h2 className="text-center text-3xl">
         Meet EVI, our <CircledText>empathic</CircledText> AI voice
       </h2>
       <div className="w-fit">


### PR DESCRIPTION
Centered the intro screen content and ran prettier on the ConversationFrame component

(Close button still works!) 

<img width="417" alt="Screenshot 2024-03-13 at 11 40 38 AM" src="https://github.com/HumeAI/empathic-voice-api-js/assets/41601131/29201527-ba96-4649-b955-74ff5908e946">
