### PR TITLE
add support for ChatMetadataMessage

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export * from './models/assistant-message';
 export * from './models/audio-message';
 export * from './models/audio-output-message';
 export * from './models/auth';
+export * from './models/chat-metadata-message';
 export * from './models/error-message';
 export * from './models/json-message';
 export * from './models/session-settings';

--- a/packages/core/src/models/chat-metadata-message.ts
+++ b/packages/core/src/models/chat-metadata-message.ts
@@ -1,0 +1,14 @@
+import z from 'zod';
+
+export const ChatMetadataMessageSchema = z
+  .object({
+    type: z.literal('chat_metadata'),
+    chat_id: z.string(),
+  })
+  .transform((obj) => {
+    return Object.assign(obj, {
+      receivedAt: new Date(),
+    });
+  });
+
+export type ChatMetadataMessage = z.infer<typeof ChatMetadataMessageSchema>;

--- a/packages/core/src/models/json-message.ts
+++ b/packages/core/src/models/json-message.ts
@@ -3,6 +3,7 @@ import z from 'zod';
 import { AssistantEndMessageSchema } from './assistant-end-message';
 import { AssistantTranscriptMessageSchema } from './assistant-message';
 import { AudioOutputMessageSchema } from './audio-output-message';
+import { ChatMetadataMessageSchema } from './chat-metadata-message';
 import { JSONErrorMessageSchema } from './error-message';
 import {
   ToolCallSchema,
@@ -22,6 +23,7 @@ export const JSONMessageSchema = z.union([
   ToolCallSchema,
   ToolErrorSchema,
   ToolResponseSchema,
+  ChatMetadataMessageSchema,
 ]);
 
 export type JSONMessage = z.infer<typeof JSONMessageSchema>;

--- a/packages/embed-react/package.json
+++ b/packages/embed-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed-react",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/embed-react/src/index.ts
+++ b/packages/embed-react/src/index.ts
@@ -22,4 +22,5 @@ export type {
   ToolCall,
   ToolResponse,
   ToolError,
+  ChatMetadataMessage,
 } from '@humeai/voice-embed';

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/embed/src/index.ts
+++ b/packages/embed/src/index.ts
@@ -21,6 +21,7 @@ export type {
   ToolCall,
   ToolResponse,
   ToolError,
+  ChatMetadataMessage,
 } from '@humeai/voice';
 
 export { LanguageModelOption } from '@humeai/voice';

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-react",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -20,5 +20,6 @@ export {
   type ToolCall,
   type ToolResponse,
   type ToolError,
+  type ChatMetadataMessage,
   LanguageModelOption,
 } from '@humeai/voice';

--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -1,6 +1,7 @@
 import {
   AssistantTranscriptMessage,
   AudioOutputMessage,
+  ChatMetadataMessage,
   createSocketConfig,
   JSONErrorMessage,
   JSONMessage,
@@ -69,6 +70,7 @@ export type VoiceContextType = {
     | ToolCall
     | ToolResponse
     | ToolError
+    | ChatMetadataMessage
   )[];
   lastVoiceMessage: AssistantTranscriptMessage | null;
   lastUserMessage: UserTranscriptMessage | null;
@@ -202,7 +204,8 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
           | JSONErrorMessage
           | ToolCall
           | ToolResponse
-          | ToolError,
+          | ToolError
+          | ChatMetadataMessage,
       ) => {
         // store message
         messageStore.onMessage(message);

--- a/packages/react/src/lib/useMessages.ts
+++ b/packages/react/src/lib/useMessages.ts
@@ -1,4 +1,5 @@
 import type {
+  ChatMetadataMessage,
   JSONErrorMessage,
   ToolCall,
   ToolError,
@@ -27,7 +28,8 @@ export const useMessages = ({
       | JSONErrorMessage
       | ToolCall
       | ToolResponse
-      | ToolError,
+      | ToolError
+      | ChatMetadataMessage,
   ) => void;
   messageHistoryLimit: number;
 }) => {
@@ -45,6 +47,7 @@ export const useMessages = ({
       | ToolCall
       | ToolResponse
       | ToolError
+      | ChatMetadataMessage
     >
   >([]);
 
@@ -101,30 +104,11 @@ export const useMessages = ({
         });
         break;
       case 'user_interruption':
-        sendMessageToParent?.(message);
-        setMessages((prev) => {
-          return keepLastN(messageHistoryLimit, prev.concat([message]));
-        });
-        break;
       case 'error':
-        sendMessageToParent?.(message);
-        setMessages((prev) => {
-          return keepLastN(messageHistoryLimit, prev.concat([message]));
-        });
-        break;
       case 'tool_call':
-        sendMessageToParent?.(message);
-        setMessages((prev) => {
-          return keepLastN(messageHistoryLimit, prev.concat([message]));
-        });
-        break;
       case 'tool_response':
-        sendMessageToParent?.(message);
-        setMessages((prev) => {
-          return keepLastN(messageHistoryLimit, prev.concat([message]));
-        });
-        break;
       case 'tool_error':
+      case 'chat_metadata':
         sendMessageToParent?.(message);
         setMessages((prev) => {
           return keepLastN(messageHistoryLimit, prev.concat([message]));

--- a/packages/react/src/lib/useVoiceClient.ts
+++ b/packages/react/src/lib/useVoiceClient.ts
@@ -1,6 +1,7 @@
 import type {
   AssistantTranscriptMessage,
   AudioOutputMessage,
+  ChatMetadataMessage,
   JSONErrorMessage,
   SessionSettings,
   SocketConfig,
@@ -49,7 +50,8 @@ export const useVoiceClient = (props: {
       | JSONErrorMessage
       | ToolCall
       | ToolResponse
-      | ToolError,
+      | ToolError
+      | ChatMetadataMessage,
   ) => void;
   onToolCall?: ToolCallHandler;
   onError?: (message: string, error?: Error) => void;
@@ -105,7 +107,8 @@ export const useVoiceClient = (props: {
           message.type === 'user_interruption' ||
           message.type === 'error' ||
           message.type === 'tool_response' ||
-          message.type === 'tool_error'
+          message.type === 'tool_error' ||
+          message.type === 'chat_metadata'
         ) {
           onMessage.current?.(message);
         }


### PR DESCRIPTION
* add support for message type `chat_metadata`
* bump version to 0.1.4 because all clients need to be updated before the corresponding backend change can be deployed