### PR TITLE
removed muted check in mic data handler

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/embed-react/package.json
+++ b/packages/embed-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed-react",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-react",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/src/lib/useMicrophone.ts
+++ b/packages/react/src/lib/useMicrophone.ts
@@ -33,11 +33,6 @@ export const useMicrophone = (props: MicrophoneProps) => {
   sendAudio.current = onAudioCaptured;
 
   const dataHandler = useCallback((event: BlobEvent) => {
-    if (isMutedRef.current) {
-      // Do not send audio if the microphone is muted
-      return;
-    }
-
     const blob = event.data;
 
     blob


### PR DESCRIPTION
Turns out that setting the `enabled` property on the `MediaStreamTrack` automatically takes care of generating 0-filled frames to represent silence. We can just remove the mute check on the data handler and let it do its thing. Ref: https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/enabled