### PR TITLE
Prop for Muting EVI (HUME-5424)

### DIFF
--- a/examples/next-app/components/ExampleComponent.tsx
+++ b/examples/next-app/components/ExampleComponent.tsx
@@ -29,10 +29,13 @@ export const ExampleComponent = () => {
     fft: audioFft,
     status,
     isMuted,
+    isEVIMuted,
     isPlaying,
     mute,
+    muteEVI,
     readyState,
     unmute,
+    unmuteEVI,
     messages,
     micFft,
     callDurationTimestamp,
@@ -126,6 +129,12 @@ export const ExampleComponent = () => {
                     Mute mic
                   </button>
                 )}
+                <button
+                  className="rounded border border-neutral-500 p-2"
+                  onClick={() => (isEVIMuted ? unmuteEVI() : muteEVI())}
+                >
+                  {isEVIMuted ? 'Unmute EVI' : 'Mute EVI'}
+                </button>
 
                 <div className="flex gap-10">
                   <Waveform fft={audioFft} />

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -107,6 +107,8 @@ export const ExampleComponent = () => {
 | `clearMessages: () => void` | Clear transcript messages from history.                                   |
 | `mute: () => void` | Mute the microphone                                   |
 | `unmute: () => void` | Unmute the microphone                                   |
+| `muteEVI: () => void` | Mute EVI                                   |
+| `unmuteEVI: () => void` | Unmute EVI                                   |
 | `sendSessionSettings: (text: string) => void` | Send new session settings to the assistant. This overrides any session settings that were passed as props to the VoiceProvider.                                   |
 | `sendUserInput: (text: string) => void` | Send a user input message.                                   |
 | `sendAssistantInput: (text: string) => void` | Send a text string for the assistant to read out loud.                                   |
@@ -119,6 +121,7 @@ export const ExampleComponent = () => {
 | Property                      | Type                                          | Description                                            |
 |-----------------------------|-----------------------------------------------|--------------------------------------------------------|
 | `isMuted`                   | `boolean`                                       | Boolean that describes whether the microphone is muted |
+| `isEVIMuted`                   | `boolean`                                       | Boolean that describes whether EVI is muted |
 | `isPlaying`    | `boolean` |   Describes whether the assistant audio is currently playing.                                                     |
 | `fft` | `number[]` |            Audio FFT values for the assistant audio output.              |                                     |
 | `micFft` | `number[]` |           Audio FFT values for microphone input.              |                                     |

--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -60,6 +60,7 @@ export type VoiceContextType = {
   disconnect: () => void;
   fft: number[];
   isMuted: boolean;
+  isEVIMuted: boolean;
   isPlaying: boolean;
   messages: (
     | UserTranscriptMessage
@@ -77,6 +78,8 @@ export type VoiceContextType = {
   clearMessages: () => void;
   mute: () => void;
   unmute: () => void;
+  muteEVI: () => void;
+  unmuteEVI: () => void;
   readyState: VoiceReadyState;
   sendUserInput: VoiceClient['sendUserInput'];
   sendAssistantInput: VoiceClient['sendAssistantInput'];
@@ -370,12 +373,14 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
         fft: player.fft,
         micFft: mic.fft,
         isMuted: mic.isMuted,
+        isEVIMuted: player.isEVIMuted,
         isPlaying: player.isPlaying,
         messages: messageStore.messages,
         lastVoiceMessage: messageStore.lastVoiceMessage,
         lastUserMessage: messageStore.lastUserMessage,
         clearMessages: messageStore.clearMessages,
         mute: mic.mute,
+        muteEVI: player.muteEVI,
         readyState: client.readyState,
         sendUserInput: client.sendUserInput,
         sendAssistantInput: client.sendAssistantInput,
@@ -385,6 +390,7 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
         sendResumeAssistantMessage: client.sendResumeAssistantMessage,
         status,
         unmute: mic.unmute,
+        unmuteEVI: player.unmuteEVI,
         error,
         isAudioError,
         isError,
@@ -398,6 +404,9 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
       disconnect,
       player.fft,
       player.isPlaying,
+      player.isEVIMuted,
+      player.muteEVI,
+      player.unmuteEVI,
       mic.fft,
       mic.isMuted,
       mic.mute,


### PR DESCRIPTION
**Summary**

Currently, we do not have a prop in the React SDK for muting EVI. This PR gives developers the ability to mute EVI with the following additions:
- Adds the `muteEVI` method for stopping audio playback
- Adds the `unmuteEVI` method for resuming audio playback starting from the next clip
- Adds the `isEVIMuted` property for describing whether EVI is muted

**Changes**
- Change `useSoundPlayer` to include two methods for muting and unmuting EVI
- Change `playNextClip` logic in `useSoundPlayer` to skip audio playback
- Update the `next-app` project with a "mute EVI" button for testing purposes
- Update README to include the added methods and property