### PR TITLE
expose chat metadata from voice hook

### DIFF
--- a/examples/next-app/components/ExampleComponent.tsx
+++ b/examples/next-app/components/ExampleComponent.tsx
@@ -43,6 +43,7 @@ export const ExampleComponent = () => {
     sendAssistantInput,
     sendResumeAssistantMessage,
     sendPauseAssistantMessage,
+    chatMetadata,
   } = useVoice();
 
   const [textValue, setTextValue] = useState('');
@@ -59,7 +60,7 @@ export const ExampleComponent = () => {
       sendPauseAssistantMessage();
       setPaused(true);
     }
-  }, [paused]);
+  }, [paused, sendPauseAssistantMessage, sendResumeAssistantMessage]);
   const pausedText = paused ? 'Resume' : 'Pause';
 
   const assistantMessages = useMemo(() => {
@@ -103,6 +104,12 @@ export const ExampleComponent = () => {
                       Ready state
                     </div>
                     <div>{readyState}</div>
+                  </div>
+                  <div>
+                    <div className={'text-sm font-medium uppercase'}>
+                      Request ID
+                    </div>
+                    <div>{chatMetadata?.request_id}</div>
                   </div>
                 </div>
 

--- a/packages/core/src/models/chat-metadata-message.ts
+++ b/packages/core/src/models/chat-metadata-message.ts
@@ -5,6 +5,7 @@ export const ChatMetadataMessageSchema = z
     type: z.literal('chat_metadata'),
     chat_id: z.string(),
     chat_group_id: z.string(),
+    request_id: z.string(),
   })
   .transform((obj) => {
     return Object.assign(obj, {

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -138,6 +138,7 @@ export const ExampleComponent = () => {
 | `isSocketError` | `boolean` | If true, there was an error connecting to the websocket.      |          
 | `callDurationTimestamp` | `string` or `null` | The length of a call. This value persists after the conversation has ended.      |          
 | `toolStatusStore` | `Record<string, { call?: ToolCall; resolved?: ToolResponse | ToolError }>` | A map of tool call IDs to their associated tool messages.     |          
+| `chatMetadata` | `ChatMetadataMessage` or `null` | Metadata about the current chat, including chat ID, chat group ID, and request ID.    |          
 
 
 

--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -96,6 +96,7 @@ export type VoiceContextType = {
   isSocketError: boolean;
   callDurationTimestamp: string | null;
   toolStatusStore: ReturnType<typeof useToolStatus>['store'];
+  chatMetadata: ChatMetadataMessage | null;
 };
 
 const VoiceContext = createContext<VoiceContextType | null>(null);
@@ -180,7 +181,7 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
       stopTimer();
       updateError({ type: 'socket_error', message, error: err });
     },
-    [updateError],
+    [stopTimer, updateError],
   );
 
   const config = createSocketConfig(props);
@@ -227,7 +228,7 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
           toolStatus.addToStore(message);
         }
       },
-      [player],
+      [messageStore, player, toolStatus],
     ),
     onError: onClientError,
     onOpen: useCallback(() => {
@@ -322,7 +323,7 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
       };
       updateError(error);
     }
-  }, [client, config, getStream, mic, player, updateError]);
+  }, [client, config, getStream, mic, player, sessionSettings, updateError]);
 
   const disconnectFromVoice = useCallback(() => {
     client.disconnect();
@@ -332,7 +333,14 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
       messageStore.clearMessages();
     }
     toolStatus.clearStore();
-  }, [client, player, mic]);
+  }, [
+    client,
+    player,
+    mic,
+    clearMessagesOnDisconnect,
+    toolStatus,
+    messageStore,
+  ]);
 
   const disconnect = useCallback(
     (disconnectOnError?: boolean) => {
@@ -398,6 +406,7 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
         isSocketError,
         callDurationTimestamp,
         toolStatusStore: toolStatus.store,
+        chatMetadata: messageStore.chatMetadata,
       }) satisfies VoiceContextType,
     [
       connect,
@@ -430,6 +439,7 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
       isSocketError,
       callDurationTimestamp,
       toolStatus,
+      messageStore.chatMetadata,
     ],
   );
 

--- a/packages/react/src/lib/useMessages.ts
+++ b/packages/react/src/lib/useMessages.ts
@@ -56,6 +56,10 @@ export const useMessages = ({
   const [lastUserMessage, setLastUserMessage] =
     useState<UserTranscriptMessage | null>(null);
 
+  const [chatMetadata, setChatMetadata] = useState<ChatMetadataMessage | null>(
+    null,
+  );
+
   const createConnectMessage = useCallback(() => {
     setMessages((prev) =>
       prev.concat([
@@ -108,11 +112,17 @@ export const useMessages = ({
       case 'tool_call':
       case 'tool_response':
       case 'tool_error':
+        sendMessageToParent?.(message);
+        setMessages((prev) => {
+          return keepLastN(messageHistoryLimit, prev.concat([message]));
+        });
+        break;
       case 'chat_metadata':
         sendMessageToParent?.(message);
         setMessages((prev) => {
           return keepLastN(messageHistoryLimit, prev.concat([message]));
         });
+        setChatMetadata(message);
         break;
       default:
         break;
@@ -159,5 +169,6 @@ export const useMessages = ({
     messages,
     lastVoiceMessage,
     lastUserMessage,
+    chatMetadata,
   };
 };


### PR DESCRIPTION
* add request ID to ChatMetadata
* expose chat metadata message as a first-class citizen from the hook so users can reference it more easily
* fixed some hook dependency warnings