### PR TITLE
feat: onAssistantEnd handler to voice provider

### DIFF
--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -91,6 +91,9 @@ export type VoiceProviderProps = PropsWithChildren<SocketConfig> & {
   onOpen?: () => void;
   onClose?: Hume.empathicVoice.chat.ChatSocket.EventHandlers['close'];
   onToolCall?: ToolCallHandler;
+  onAssistantEnd?: (
+    message: Hume.empathicVoice.JsonMessage & { receivedAt: Date },
+  ) => void;
   /**
    * @default true
    * @description Clear messages when the voice is disconnected.
@@ -204,6 +207,7 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
       },
       [messageStore, player, toolStatus],
     ),
+    onAssistantEnd: props.onAssistantEnd,
     onError: onClientError,
     onOpen: useCallback(() => {
       startTimer();

--- a/packages/react/src/lib/useVoiceClient.ts
+++ b/packages/react/src/lib/useVoiceClient.ts
@@ -36,6 +36,9 @@ export const useVoiceClient = (props: {
   onMessage?: (
     message: Hume.empathicVoice.JsonMessage & { receivedAt: Date },
   ) => void;
+  onAssistantEnd?: (
+    message: Hume.empathicVoice.JsonMessage & { receivedAt: Date },
+  ) => void;
   onToolCall?: ToolCallHandler;
   onError?: (message: string, error?: Error) => void;
   onOpen?: () => void;
@@ -68,6 +71,9 @@ export const useVoiceClient = (props: {
 
   const onClose = useRef<typeof props.onClose>(props.onClose);
   onClose.current = props.onClose;
+
+  const onAssistantEnd = useRef<typeof props.onAssistantEnd>(props.onAssistantEnd);
+  onAssistantEnd.current = props.onAssistantEnd;
 
   const connect = useCallback((config: SocketConfig) => {
     return new Promise((resolve, reject) => {
@@ -109,6 +115,11 @@ export const useVoiceClient = (props: {
           const messageWithReceivedAt = { ...message, receivedAt: new Date() };
           onMessage.current?.(messageWithReceivedAt);
         }
+
+        if(message.type === "assistant_end"){
+          const messageWithReceivedAt = { ...message, receivedAt: new Date() };
+          onAssistantEnd.current?.(messageWithReceivedAt);
+        } 
 
         if (message.type === 'tool_call') {
           const messageWithReceivedAt = { ...message, receivedAt: new Date() };


### PR DESCRIPTION
This would allow me to derive a more detailed state of the assistant.

I want to show a "waiting" indicator to the user so that they know if the assistant finished and await the response.

This could help with some of the UX issues regarding uncertainty about the assistants state.

if we could show a 'thinking' indicator too while the assistants response is loading then this would be ideal, but for now this would be a helpful first step.