### PR TITLE
fix: allow assistant end messages to be sent to parent

### DIFF
--- a/packages/react/src/lib/useMessages.ts
+++ b/packages/react/src/lib/useMessages.ts
@@ -85,6 +85,7 @@ export const useMessages = ({
         case 'tool_call':
         case 'tool_response':
         case 'tool_error':
+        case 'assistant_end':
           sendMessageToParent?.(message);
           setMessages((prev) => {
             return keepLastN(messageHistoryLimit, prev.concat([message]));


### PR DESCRIPTION
@zachkrall Thank you for attempting to fix this issue in your recent commits.

While the the voice client now handles `assistant_end` messages, the message store does not. This means that the `onMessage` handler passed to the `VoiceProvider` still does not support `assistant_end` messages.

I have implemented the fix here