### PR TITLE
remove tool response and error parser

### DIFF
--- a/packages/embed-react/package.json
+++ b/packages/embed-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed-react",
-  "version": "0.1.12-beta.1",
+  "version": "0.1.12-beta.2",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed",
-  "version": "0.1.12-beta.1",
+  "version": "0.1.12-beta.2",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-react",
-  "version": "0.1.12-beta.1",
+  "version": "0.1.12-beta.2",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/src/lib/useVoiceClient.ts
+++ b/packages/react/src/lib/useVoiceClient.ts
@@ -1,5 +1,4 @@
 import { type Hume, HumeClient } from 'hume';
-import * as serializers from 'hume/serialization';
 import { useCallback, useRef, useState } from 'react';
 
 import { type AuthStrategy } from './auth';
@@ -147,17 +146,11 @@ export const useVoiceClient = (props: {
               }),
             })
             .then((response) => {
-              // check that response is a correctly formatted response or error payload
-              const parsedResponse =
-                serializers.empathicVoice.ToolResponseMessage.parse(response);
-              const parsedError =
-                serializers.empathicVoice.ToolErrorMessage.parse(response);
-
               // if valid send it to the socket
               // otherwise, report error
-              if (response.type === 'tool_response' && parsedResponse.ok) {
+              if (response.type === 'tool_response') {
                 client.current?.sendToolResponseMessage(response);
-              } else if (response.type === 'tool_error' && parsedError.ok) {
+              } else if (response.type === 'tool_error') {
                 client.current?.sendToolErrorMessage(response);
               } else {
                 onError.current?.('Invalid response from tool call');


### PR DESCRIPTION
Fixes tool calling. The fern serializer was failing because it was expecting snake case, but response keys are transformed into camelcase by the fern SDK