### PR TITLE
clear player queue when assistant is paused

### DIFF
--- a/examples/next-app/components/ExampleComponent.tsx
+++ b/examples/next-app/components/ExampleComponent.tsx
@@ -43,8 +43,8 @@ export const ExampleComponent = () => {
     callDurationTimestamp,
     sendUserInput,
     sendAssistantInput,
-    sendResumeAssistantMessage,
-    sendPauseAssistantMessage,
+    pauseAssistant,
+    resumeAssistant,
     chatMetadata,
     playerQueueLength,
   } = useVoice();
@@ -57,13 +57,13 @@ export const ExampleComponent = () => {
 
   const togglePaused = useCallback(() => {
     if (paused) {
-      sendResumeAssistantMessage({});
+      resumeAssistant();
       setPaused(false);
     } else {
-      sendPauseAssistantMessage({});
+      pauseAssistant();
       setPaused(true);
     }
-  }, [paused, sendPauseAssistantMessage, sendResumeAssistantMessage]);
+  }, [paused, resumeAssistant, pauseAssistant]);
   const pausedText = paused ? 'Resume' : 'Pause';
 
   const assistantMessages = useMemo(() => {

--- a/packages/embed-react/package.json
+++ b/packages/embed-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed-react",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -113,8 +113,8 @@ export const ExampleComponent = () => {
 | `sendUserInput: (text: string) => void`                             | Send a user input message.                                                                                                          |
 | `sendAssistantInput: (text: string) => void`                        | Send a text string for the assistant to read out loud.                                                                              |
 | `sendToolMessage: (toolMessage: ToolResponse \| ToolError) => void` | Send a tool response or tool error message to the EVI backend.                                                                      |
-| `sendPauseAssistantMessage: () => void`                             | Send pause assistant message to the websocket. This pauses responses from EVI. Chat history is still saved and sent after resuming. |
-| `sendResumeAssistantMessage: () => void`                            | Send resume assistant message to the websocket. This resumes responses from EVI. Chat history sent while paused will now be sent.   |
+| `pauseAssistant: () => void`                             | Pauses responses from EVI. Chat history is still saved and sent after resuming. |
+| `resumeAssistant: () => void`                            | Resumes responses from EVI. Chat history sent while paused will now be sent.   |
 
 ### Properties
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-react",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -68,8 +68,8 @@ export type VoiceContextType = {
       | Hume.empathicVoice.ToolResponseMessage
       | Hume.empathicVoice.ToolErrorMessage,
   ) => void;
-  sendPauseAssistantMessage: Hume.empathicVoice.chat.ChatSocket['pauseAssistant'];
-  sendResumeAssistantMessage: Hume.empathicVoice.chat.ChatSocket['resumeAssistant'];
+  pauseAssistant: () => void;
+  resumeAssistant: () => void;
   status: VoiceStatus;
   micFft: number[];
   error: VoiceError | null;
@@ -247,6 +247,15 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
     ),
   });
 
+  const pauseAssistant = useCallback(() => {
+    client.sendPauseAssistantMessage();
+    player.clearQueue();
+  }, [client, player]);
+
+  const resumeAssistant = useCallback(() => {
+    client.sendResumeAssistantMessage();
+  }, [client]);
+
   const connect = useCallback(async () => {
     updateError(null);
     setStatus({ value: 'connecting' });
@@ -383,8 +392,8 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
         sendUserInput: client.sendUserInput,
         sendAssistantInput: client.sendAssistantInput,
         sendSessionSettings: client.sendSessionSettings,
-        sendPauseAssistantMessage: client.sendPauseAssistantMessage,
-        sendResumeAssistantMessage: client.sendResumeAssistantMessage,
+        pauseAssistant,
+        resumeAssistant,
         sendToolMessage: client.sendToolMessage,
         status,
         unmute: mic.unmute,
@@ -403,8 +412,8 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
       connect,
       disconnect,
       player.fft,
-      player.isPlaying,
       player.isAudioMuted,
+      player.isPlaying,
       player.muteAudio,
       player.unmuteAudio,
       player.queueLength,
@@ -416,13 +425,14 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
       messageStore.lastVoiceMessage,
       messageStore.lastUserMessage,
       messageStore.clearMessages,
+      messageStore.chatMetadata,
       client.readyState,
       client.sendUserInput,
       client.sendAssistantInput,
       client.sendSessionSettings,
       client.sendToolMessage,
-      client.sendPauseAssistantMessage,
-      client.sendResumeAssistantMessage,
+      pauseAssistant,
+      resumeAssistant,
       status,
       error,
       isAudioError,
@@ -430,8 +440,7 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
       isMicrophoneError,
       isSocketError,
       callDurationTimestamp,
-      toolStatus,
-      messageStore.chatMetadata,
+      toolStatus.store,
     ],
   );
 


### PR DESCRIPTION
Also renames the method names because pausing the assistant now does more than just send a pause message (breaking change)