### PR TITLE
Add readyState check for connection closed

### DIFF
--- a/packages/embed-react/package.json
+++ b/packages/embed-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed-react",
-  "version": "0.1.15-beta.1",
+  "version": "0.1.15-beta.2",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed",
-  "version": "0.1.15-beta.1",
+  "version": "0.1.15-beta.2",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-react",
-  "version": "0.1.15-beta.1",
+  "version": "0.1.15-beta.2",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -235,12 +235,15 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
     streamRef,
     onAudioCaptured: useCallback((arrayBuffer) => {
       try {
+        if (client.readyState !== 'open') {
+          throw new Error('Socket is not open');
+        }
         client.sendAudio(arrayBuffer);
       } catch (e) {
         const message = e instanceof Error ? e.message : 'Unknown error';
         updateError({ type: 'socket_error', message });
       }
-    }, []),
+    }, [client.readyState]),
     onError: useCallback(
       (message) => {
         updateError({ type: 'mic_error', message });
@@ -365,6 +368,12 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
       disconnectFromVoice();
     }
   }, [status.value, disconnect, disconnectFromVoice, error]);
+
+  useEffect(() => {
+    if (error === null && client.readyState === 'closed') {
+      disconnectFromVoice();
+    }
+  }, [client.readyState]);
 
   useEffect(() => {
     // disconnect from socket when the voice provider component unmounts

--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -233,17 +233,20 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
 
   const mic = useMicrophone({
     streamRef,
-    onAudioCaptured: useCallback((arrayBuffer) => {
-      try {
-        if (client.readyState !== 'open') {
-          throw new Error('Socket is not open');
+    onAudioCaptured: useCallback(
+      (arrayBuffer) => {
+        try {
+          if (client.readyState !== 'open') {
+            throw new Error('Socket is not open');
+          }
+          client.sendAudio(arrayBuffer);
+        } catch (e) {
+          const message = e instanceof Error ? e.message : 'Unknown error';
+          updateError({ type: 'socket_error', message });
         }
-        client.sendAudio(arrayBuffer);
-      } catch (e) {
-        const message = e instanceof Error ? e.message : 'Unknown error';
-        updateError({ type: 'socket_error', message });
-      }
-    }, [client.readyState]),
+      },
+      [client.readyState],
+    ),
     onError: useCallback(
       (message) => {
         updateError({ type: 'mic_error', message });
@@ -368,12 +371,6 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
       disconnectFromVoice();
     }
   }, [status.value, disconnect, disconnectFromVoice, error]);
-
-  useEffect(() => {
-    if (error === null && client.readyState === 'closed') {
-      disconnectFromVoice();
-    }
-  }, [client.readyState]);
 
   useEffect(() => {
     // disconnect from socket when the voice provider component unmounts

--- a/packages/react/src/lib/useVoiceClient.ts
+++ b/packages/react/src/lib/useVoiceClient.ts
@@ -212,24 +212,36 @@ export const useVoiceClient = (props: {
 
   const sendSessionSettings = useCallback(
     (sessionSettings: Hume.empathicVoice.SessionSettings) => {
+      if (readyState !== VoiceReadyState.OPEN) {
+        throw new Error('Socket is not open');
+      }
       client.current?.sendSessionSettings(sessionSettings);
     },
-    [],
+    [readyState],
   );
 
   const sendAudio = useCallback((arrayBuffer: ArrayBufferLike) => {
+    if (readyState !== VoiceReadyState.OPEN) {
+      throw new Error('Socket is not open');
+    }
     client.current?.socket?.send(arrayBuffer);
-  }, []);
+  }, [readyState]);
 
   const sendUserInput = useCallback((text: string) => {
+    if (readyState !== VoiceReadyState.OPEN) {
+      throw new Error('Socket is not open');
+    }
     client.current?.sendUserInput(text);
-  }, []);
+  }, [readyState]);
 
   const sendAssistantInput = useCallback((text: string) => {
+    if (readyState !== VoiceReadyState.OPEN) {
+      throw new Error('Socket is not open');
+    }
     client.current?.sendAssistantInput({
       text,
     });
-  }, []);
+  }, [readyState]);
 
   const sendToolMessage = useCallback(
     (
@@ -239,21 +251,30 @@ export const useVoiceClient = (props: {
         | Hume.empathicVoice.ToolResponseMessage
         | Hume.empathicVoice.ToolErrorMessage,
     ) => {
+      if (readyState !== VoiceReadyState.OPEN) {
+        throw new Error('Socket is not open');
+      }
       if (toolMessage.type === 'tool_error') {
         client.current?.sendToolErrorMessage(toolMessage);
       } else {
         client.current?.sendToolResponseMessage(toolMessage);
       }
     },
-    [],
+    [readyState],
   );
 
   const sendPauseAssistantMessage = useCallback(() => {
+    if (readyState !== VoiceReadyState.OPEN) {
+      throw new Error('Socket is not open');
+    }
     client.current?.pauseAssistant({});
-  }, []);
+  }, [readyState]);
   const sendResumeAssistantMessage = useCallback(() => {
+    if (readyState !== VoiceReadyState.OPEN) {
+      throw new Error('Socket is not open');
+    }
     client.current?.resumeAssistant({});
-  }, []);
+  }, [readyState]);
 
   return {
     readyState,

--- a/packages/react/src/lib/useVoiceClient.ts
+++ b/packages/react/src/lib/useVoiceClient.ts
@@ -220,28 +220,37 @@ export const useVoiceClient = (props: {
     [readyState],
   );
 
-  const sendAudio = useCallback((arrayBuffer: ArrayBufferLike) => {
-    if (readyState !== VoiceReadyState.OPEN) {
-      throw new Error('Socket is not open');
-    }
-    client.current?.socket?.send(arrayBuffer);
-  }, [readyState]);
+  const sendAudio = useCallback(
+    (arrayBuffer: ArrayBufferLike) => {
+      if (readyState !== VoiceReadyState.OPEN) {
+        throw new Error('Socket is not open');
+      }
+      client.current?.socket?.send(arrayBuffer);
+    },
+    [readyState],
+  );
 
-  const sendUserInput = useCallback((text: string) => {
-    if (readyState !== VoiceReadyState.OPEN) {
-      throw new Error('Socket is not open');
-    }
-    client.current?.sendUserInput(text);
-  }, [readyState]);
+  const sendUserInput = useCallback(
+    (text: string) => {
+      if (readyState !== VoiceReadyState.OPEN) {
+        throw new Error('Socket is not open');
+      }
+      client.current?.sendUserInput(text);
+    },
+    [readyState],
+  );
 
-  const sendAssistantInput = useCallback((text: string) => {
-    if (readyState !== VoiceReadyState.OPEN) {
-      throw new Error('Socket is not open');
-    }
-    client.current?.sendAssistantInput({
-      text,
-    });
-  }, [readyState]);
+  const sendAssistantInput = useCallback(
+    (text: string) => {
+      if (readyState !== VoiceReadyState.OPEN) {
+        throw new Error('Socket is not open');
+      }
+      client.current?.sendAssistantInput({
+        text,
+      });
+    },
+    [readyState],
+  );
 
   const sendToolMessage = useCallback(
     (


### PR DESCRIPTION
This PR adds a check for readyState in each `send` method in the voice client as well as the audio capture handler. If an attempt is made after the readyState is closed, an error is thrown; this also subsequently ends up triggering disconnect cleanup tasks.