### PR TITLE
reset audio muted state when call ends

### DIFF
--- a/packages/react/src/lib/useSoundPlayer.ts
+++ b/packages/react/src/lib/useSoundPlayer.ts
@@ -165,6 +165,7 @@ export const useSoundPlayer = (props: {
     isInitialized.current = false;
     isProcessing.current = false;
     setIsPlaying(false);
+    setIsAudioMuted(false);
 
     if (frequencyDataIntervalId.current) {
       window.clearInterval(frequencyDataIntervalId.current);


### PR DESCRIPTION
Fixes issue where `isMuted` state would persist across calls