### PR TITLE
add `onAudioStart`, `onAudioEnd`, and `onInterruption` callbacks 

### DIFF
--- a/examples/next-app/components/Voice.tsx
+++ b/examples/next-app/components/Voice.tsx
@@ -16,6 +16,14 @@ export const Voice = ({ accessToken }: { accessToken: string }) => {
         // eslint-disable-next-line no-console
         console.log('message', message);
       }}
+      onAudioStart={(clipId) => {
+        // eslint-disable-next-line no-console
+        console.log('Start playing clip with ID:', clipId);
+      }}
+      onAudioEnd={(clipId) => {
+        // eslint-disable-next-line no-console
+        console.log('Stop playing clip with ID:', clipId);
+      }}
       onToolCall={useCallback<ToolCallHandler>(async (toolCall, response) => {
         if (toolCall.name === 'weather_tool') {
           try {

--- a/examples/next-app/components/Voice.tsx
+++ b/examples/next-app/components/Voice.tsx
@@ -24,6 +24,10 @@ export const Voice = ({ accessToken }: { accessToken: string }) => {
         // eslint-disable-next-line no-console
         console.log('Stop playing clip with ID:', clipId);
       }}
+      onInterruption={(message) => {
+        // eslint-disable-next-line no-console
+        console.log('Interruption triggered on the following message', message);
+      }}
       onToolCall={useCallback<ToolCallHandler>(async (toolCall, response) => {
         if (toolCall.name === 'weather_tool') {
           try {

--- a/packages/embed-react/package.json
+++ b/packages/embed-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed-react",
-  "version": "0.1.18",
+  "version": "0.1.19-beta.1",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed",
-  "version": "0.1.18",
+  "version": "0.1.19-beta.1",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -115,6 +115,10 @@ See a complete list of props accepted by `VoiceProvider` below:
 
 (_Optional_) Callback function to invoke when an audio clip from the assistant stops playing.
 
+#### `onInterruption?`: (clipId: string) => void
+
+(_Optional_) Callback function to invoke when the assistant is interrupted.
+
 #### `onClose?`: (event: [CloseEvent](https://github.com/HumeAI/hume-typescript-sdk/blob/ac89e41e45a925f9861eb6d5a1335ab51d5a1c94/src/core/websocket/events.ts#L20)) => void
 
 (_Optional_) Callback function to invoke upon the web socket connection being closed.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -107,6 +107,14 @@ See a complete list of props accepted by `VoiceProvider` below:
 
 (_Optional_) Callback function to invoke upon receiving a ToolCallMessage through the web socket. It will send the string returned as a the content of a ToolResponseMessage. This is where you should add logic that handles your custom tool calls.
 
+#### `onAudioStart?`: (clipId: string) => void
+
+(_Optional_) Callback function to invoke when an audio clip from the assistant starts playing.
+
+#### `onAudioEnd?`: (clipId: string) => void
+
+(_Optional_) Callback function to invoke when an audio clip from the assistant stops playing.
+
 #### `onClose?`: (event: [CloseEvent](https://github.com/HumeAI/hume-typescript-sdk/blob/ac89e41e45a925f9861eb6d5a1335ab51d5a1c94/src/core/websocket/events.ts#L20)) => void
 
 (_Optional_) Callback function to invoke upon the web socket connection being closed.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-react",
-  "version": "0.1.18",
+  "version": "0.1.19-beta.1",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -97,6 +97,8 @@ export type VoiceProviderProps = PropsWithChildren<SocketConfig> & {
   onOpen?: () => void;
   onClose?: Hume.empathicVoice.chat.ChatSocket.EventHandlers['close'];
   onToolCall?: ToolCallHandler;
+  onAudioStart?: (clipId: string) => void;
+  onAudioEnd?: (clipId: string) => void;
   /**
    * @default true
    * @description Clear messages when the voice is disconnected.
@@ -153,6 +155,12 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
   const onMessage = useRef(props.onMessage ?? noop);
   onMessage.current = props.onMessage ?? noop;
 
+  const onAudioStart = useRef(props.onAudioStart ?? noop);
+  onAudioStart.current = props.onAudioStart ?? noop;
+
+  const onAudioEnd = useRef(props.onAudioEnd ?? noop);
+  onAudioEnd.current = props.onAudioEnd ?? noop;
+
   const toolStatus = useToolStatus();
 
   const messageStore = useMessages({
@@ -185,6 +193,10 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
     },
     onPlayAudio: (id: string) => {
       messageStore.onPlayAudio(id);
+      onAudioStart.current(id);
+    },
+    onStopAudio: (id: string) => {
+      onAudioEnd.current(id);
     },
   });
 

--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -30,6 +30,7 @@ import {
   AudioOutputMessage,
   ChatMetadataMessage,
   JSONMessage,
+  UserInterruptionMessage,
   UserTranscriptMessage,
 } from '../models/messages';
 
@@ -99,6 +100,9 @@ export type VoiceProviderProps = PropsWithChildren<SocketConfig> & {
   onToolCall?: ToolCallHandler;
   onAudioStart?: (clipId: string) => void;
   onAudioEnd?: (clipId: string) => void;
+  onInterruption?: (
+    message: UserTranscriptMessage | UserInterruptionMessage,
+  ) => void;
   /**
    * @default true
    * @description Clear messages when the voice is disconnected.
@@ -161,6 +165,9 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
   const onAudioEnd = useRef(props.onAudioEnd ?? noop);
   onAudioEnd.current = props.onAudioEnd ?? noop;
 
+  const onInterruption = useRef(props.onInterruption ?? noop);
+  onInterruption.current = props.onInterruption ?? noop;
+
   const toolStatus = useToolStatus();
 
   const messageStore = useMessages({
@@ -215,6 +222,9 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
           message.type === 'user_interruption' ||
           message.type === 'user_message'
         ) {
+          if (player.isPlaying) {
+            onInterruption.current(message);
+          }
           player.clearQueue();
         }
 

--- a/packages/react/src/lib/useSoundPlayer.ts
+++ b/packages/react/src/lib/useSoundPlayer.ts
@@ -8,6 +8,7 @@ import type { AudioOutputMessage } from '../models/messages';
 export const useSoundPlayer = (props: {
   onError: (message: string) => void;
   onPlayAudio: (id: string) => void;
+  onStopAudio: (id: string) => void;
 }) => {
   const [isPlaying, setIsPlaying] = useState(false);
   const [isAudioMuted, setIsAudioMuted] = useState(false);
@@ -34,6 +35,9 @@ export const useSoundPlayer = (props: {
 
   const onPlayAudio = useRef<typeof props.onPlayAudio>(props.onPlayAudio);
   onPlayAudio.current = props.onPlayAudio;
+
+  const onStopAudio = useRef<typeof props.onStopAudio>(props.onStopAudio);
+  onStopAudio.current = props.onStopAudio;
 
   const onError = useRef<typeof props.onError>(props.onError);
   onError.current = props.onError;
@@ -105,6 +109,7 @@ export const useSoundPlayer = (props: {
       bufferSource.disconnect();
       isProcessing.current = false;
       setIsPlaying(false);
+      onStopAudio.current(nextClip.id);
       currentlyPlayingAudioBuffer.current = null;
       playNextClip();
     };


### PR DESCRIPTION
These callbacks enable the client to perform some action (e.g. logging) when an audio clip starts and ends