### PR TITLE
use correct session settings method

### DIFF
--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -469,9 +469,9 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
       sessionSettings !== undefined &&
       Object.keys(sessionSettings).length > 0
     ) {
-      clientSendSessionSettings(sessionSettings);
+      sendSessionSettings(sessionSettings);
     }
-  }, [client.readyState, clientSendSessionSettings, sessionSettings]);
+  }, [client.readyState, sendSessionSettings, sessionSettings]);
 
   const sendToolMessage = useCallback(
     (


### PR DESCRIPTION
`sendSessionSettings` wraps `clientSessionSettings` in a try/catch - the useEffect should call `sendSessionSettings` to prevent uncaught exceptions from being thrown