### PR TITLE
Wait for chat_metadata message before declaring socket open

### DIFF
--- a/packages/embed-react/package.json
+++ b/packages/embed-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed-react",
-  "version": "0.1.19",
+  "version": "0.1.20-beta.1",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed",
-  "version": "0.1.19",
+  "version": "0.1.20-beta.1",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-react",
-  "version": "0.1.19",
+  "version": "0.1.20-beta.1",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/src/lib/useVoiceClient.ts
+++ b/packages/react/src/lib/useVoiceClient.ts
@@ -100,17 +100,17 @@ export const useVoiceClient = (props: {
 
       client.current = hume.empathicVoice.chat.connect(config);
 
-      client.current.on('open', () => {
-        onOpen.current?.();
-        setReadyState(VoiceReadyState.OPEN);
-        resolve(VoiceReadyState.OPEN);
-      });
-
       client.current.on('message', (message) => {
         if (message.type === 'audio_output') {
           const messageWithReceivedAt = { ...message, receivedAt: new Date() };
           onAudioMessage.current?.(messageWithReceivedAt);
           return;
+        }
+
+        if (message.type === 'chat_metadata') {
+          onOpen.current?.();
+          setReadyState(VoiceReadyState.OPEN);
+          resolve(VoiceReadyState.OPEN);
         }
 
         if (


### PR DESCRIPTION
This ensures the handshake is complete before sending messages. 