### PR TITLE
Remove mimetype

### DIFF
--- a/packages/react/src/lib/useSoundPlayer.ts
+++ b/packages/react/src/lib/useSoundPlayer.ts
@@ -137,7 +137,7 @@ export const useSoundPlayer = (props: {
       }
 
       try {
-        const blob = convertBase64ToBlob(message.data, 'audio/mp3');
+        const blob = convertBase64ToBlob(message.data);
         const arrayBuffer = await blob.arrayBuffer();
         const audioBuffer =
           await audioContext.current.decodeAudioData(arrayBuffer);


### PR DESCRIPTION
Labeling the audio that comes back from EVI with `audio/mp3` is a lie. It's always WAV. We should just avoid labelling it, as putting a label on is unnecessary (the audio file has a header).

Merging it now will cause a Typescript error, need 
https://github.com/HumeAI/hume-typescript-sdk/pull/251
to be merged/released (and then will need to update this PR to reference the new version).