### PR TITLE
Consolidate clean up tasks for voice audio resources

### DIFF
--- a/packages/embed-react/package.json
+++ b/packages/embed-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed-react",
-  "version": "0.2.0-beta.3",
+  "version": "0.2.0-beta.4",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed",
-  "version": "0.2.0-beta.3",
+  "version": "0.2.0-beta.4",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-react",
-  "version": "0.2.0-beta.3",
+  "version": "0.2.0-beta.4",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -219,22 +219,10 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
   });
 
   const handleResourceCleanup = useCallback(() => {
-    try {
-      player.stopAll();
-      console.log('Audio player stopped');
-    } catch (e) {
-      console.error('Error stopping audio player:', e);
-    }
-
+    player.stopAll();
     if (micCleanUpRefs.current.isInitialized) {
-      try {
-        micCleanUpRefs.current.cleanup();
-        console.log('Microphone stopped');
-      } catch (e) {
-        console.error('Error stopping microphone:', e);
-      }
+      micCleanUpRefs.current.cleanup();
     }
-
     if (clearMessagesOnDisconnect) {
       messageStore.clearMessages();
     }
@@ -440,7 +428,7 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
       setStatus({ value: 'error', reason: error.message });
       disconnectFromVoice();
     }
-  }, [status.value, disconnectFromVoice, error]);
+  }, [status.value, disconnect, disconnectFromVoice, error]);
 
   useEffect(() => {
     // disconnect from socket when the voice provider component unmounts


### PR DESCRIPTION
### Context

Websocket connections can close both expectedly and unexpectedly; in the React SDK, there are multiple resources which are dependent on this connection state: microphone, player and the voice provider state itself. Depending on the path by which this connection is closed, either manually, server-side or erroneously, there can exist race conditions that leave some of these resources in unfitting state.

### Change

This PR implements a consolidated `handleResourceCleanup` function that orchestrates cleanup of player, microphone, and application state. Using refs to track microphone, the consolidated function can then be used in the `onClose` callback of the voice client, ensuring that all cleanup tasks properly run on different cases: manual disconnections, connection being closed server-side, or any type of errors occurring.