### PR TITLE
clean up some error messages

### DIFF
--- a/examples/next-app/components/Voice.tsx
+++ b/examples/next-app/components/Voice.tsx
@@ -16,6 +16,10 @@ export const Voice = ({ accessToken }: { accessToken: string }) => {
         // eslint-disable-next-line no-console
         console.log('message', message);
       }}
+      onError={(message) => {
+        // eslint-disable-next-line no-console
+        console.error('onError', message);
+      }}
       onAudioStart={(clipId) => {
         // eslint-disable-next-line no-console
         console.log('Start playing clip with ID:', clipId);

--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -183,6 +183,7 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
   });
 
   const updateError = useCallback((err: VoiceError | null) => {
+    console.log('running updateError', err);
     setError(err);
     if (err !== null) {
       onError.current?.(err);
@@ -358,7 +359,7 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
         const message = 'Microphone permission denied';
         const error: VoiceError = { type: 'mic_error', message };
         updateError(error);
-        return Promise.reject(new Error(message));
+        return;
       }
 
       try {
@@ -367,10 +368,11 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
           verboseTranscription: true,
         });
       } catch (e) {
-        const message = 'We could not connect to the voice. Please try again.';
+        const message =
+          'A websocket connection could not be established. Please try again.';
         const error: VoiceError = { type: 'socket_error', message };
         updateError(error);
-        return Promise.reject(new Error(message));
+        return;
       }
 
       try {

--- a/packages/react/src/lib/useVoiceClient.test.ts
+++ b/packages/react/src/lib/useVoiceClient.test.ts
@@ -7,7 +7,7 @@ describe('useVoiceClient', () => {
   it('creates a client with the given config', () => {
     const hook = renderHook(() =>
       useVoiceClient({
-        onError: () => {},
+        onClientError: () => {},
       }),
     );
 

--- a/packages/react/src/lib/useVoiceClient.ts
+++ b/packages/react/src/lib/useVoiceClient.ts
@@ -52,7 +52,8 @@ export const useVoiceClient = (props: {
   onAudioMessage?: (message: AudioOutputMessage) => void;
   onMessage?: (message: JSONMessage) => void;
   onToolCall?: ToolCallHandler;
-  onError?: (message: string, error?: Error) => void;
+  onToolCallError?: (message: string, error?: Error) => void;
+  onClientError?: (message: string, error?: Error) => void;
   onOpen?: () => void;
   onClose?: Hume.empathicVoice.chat.ChatSocket.EventHandlers['close'];
 }) => {
@@ -75,8 +76,13 @@ export const useVoiceClient = (props: {
   const onToolCall = useRef<typeof props.onToolCall>(props.onToolCall);
   onToolCall.current = props.onToolCall;
 
-  const onError = useRef<typeof props.onError>(props.onError);
-  onError.current = props.onError;
+  const onClientError = useRef<typeof props.onClientError>(props.onClientError);
+  onClientError.current = props.onClientError;
+
+  const onToolCallError = useRef<typeof props.onToolCallError>(
+    props.onToolCallError,
+  );
+  onToolCallError.current = props.onToolCallError;
 
   const onOpen = useRef<typeof props.onOpen>(props.onOpen);
   onOpen.current = props.onOpen;
@@ -178,7 +184,7 @@ export const useVoiceClient = (props: {
                 } else if (response.type === 'tool_error') {
                   client.current?.sendToolErrorMessage(response);
                 } else {
-                  onError.current?.('Invalid response from tool call');
+                  onToolCallError.current?.('Invalid response from tool call');
                 }
               });
           }
@@ -197,7 +203,7 @@ export const useVoiceClient = (props: {
 
       client.current.on('error', (e) => {
         const message = e instanceof Error ? e.message : 'Unknown error';
-        onError.current?.(message, e instanceof Error ? e : undefined);
+        onClientError.current?.(message, e instanceof Error ? e : undefined);
         reject(e);
       });
 


### PR DESCRIPTION
There were a couple of areas where the SDK was making duplicate `onError` calls for the same error message - specifically, SDK was catching rejected promises by calling `onError`, while also calling `updateError`, which also calls `onError`. This PR cleans up those scenarios. 

1. Removed duplicate error that was thrown when mic permissions are denied
2. Removed duplicate error that was thrown when the websocket client error callback is called
  * as part of this, we now distinguish between tool errors and client errors in the useVoiceClient hook 