### PR TITLE
Wait for empty queue on player resource cleanup

### DIFF
--- a/packages/embed-react/package.json
+++ b/packages/embed-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed-react",
-  "version": "0.2.0-beta.5",
+  "version": "0.2.0-beta.6",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed",
-  "version": "0.2.0-beta.5",
+  "version": "0.2.0-beta.6",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-react",
-  "version": "0.2.0-beta.5",
+  "version": "0.2.0-beta.6",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -215,20 +215,20 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
       onAudioEnd.current(id);
     },
   });
-  const [shouldClosePlayer, setShouldClosePlayer] = useState(false);
+  const [shouldStopPlayer, setShouldStopPlayer] = useState(false);
 
   useEffect(() => {
     if (
-      shouldClosePlayer &&
+      shouldStopPlayer &&
       (player.queueLength === 0 || status.value === 'error')
     ) {
       player.stopAll();
-      setShouldClosePlayer(false);
+      setShouldStopPlayer(false);
     }
-  }, [shouldClosePlayer, player.queueLength, player, status.value]);
+  }, [shouldStopPlayer, player.queueLength, player, status.value]);
 
   const handleResourceCleanup = useCallback(() => {
-    setShouldClosePlayer(true);
+    setShouldStopPlayer(true);
     if (micCleanUpFnRef.current !== null) {
       micCleanUpFnRef.current();
     }
@@ -280,7 +280,7 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
       startTimer();
       messageStore.createConnectMessage();
       props.onOpen?.();
-      setShouldClosePlayer(false);
+      setShouldStopPlayer(false);
     }, [messageStore, props, startTimer]),
     onClose: useCallback<
       NonNullable<Hume.empathicVoice.chat.ChatSocket.EventHandlers['close']>


### PR DESCRIPTION
When the websocket connection closes, resource cleanup happens immediately, even if there are some audio chunks still in the queue, such as a goodbye message.
This PR sets a state flag to track the player cleanup requirement, and triggers the stoppage once the queue has been fully emptied.