### PR TITLE
Make cleanup immediate on demand

### DIFF
--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -228,21 +228,28 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
     }
   }, [shouldStopPlayer, player.queueLength, player, status.value]);
 
-  const handleResourceCleanup = useCallback(() => {
-    setShouldStopPlayer(true);
-    if (micCleanUpFnRef.current !== null) {
-      micCleanUpFnRef.current();
-    }
-    if (clearMessagesOnDisconnect) {
-      messageStore.clearMessages();
-    }
-    toolStatus.clearStore();
-    setIsPaused(false);
+  const handleResourceCleanup = useCallback(
+    (forceStop?: boolean) => {
+      if (forceStop) {
+        player.stopAll();
+      } else {
+        setShouldStopPlayer(true);
+      }
+      if (micCleanUpFnRef.current !== null) {
+        micCleanUpFnRef.current();
+      }
+      if (clearMessagesOnDisconnect) {
+        messageStore.clearMessages();
+      }
+      toolStatus.clearStore();
+      setIsPaused(false);
 
-    if (status.value !== 'error') {
-      setStatus({ value: 'disconnected' });
-    }
-  }, [clearMessagesOnDisconnect, messageStore, toolStatus, status.value]);
+      if (status.value !== 'error') {
+        setStatus({ value: 'disconnected' });
+      }
+    },
+    [clearMessagesOnDisconnect, toolStatus, status.value, player, messageStore],
+  );
 
   const { streamRef, getStream, permission: micPermission } = useEncoding();
 
@@ -420,7 +427,8 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
     if (client.readyState !== VoiceReadyState.CLOSED) {
       client.disconnect();
     }
-    handleResourceCleanup();
+    // Cleanup resources immediately
+    handleResourceCleanup(true);
   }, [client, handleResourceCleanup]);
 
   const disconnect = useCallback(


### PR DESCRIPTION
### Context

The voice provider in the SDK handles resource cleanup when disconnecting or unmounting. However, in all cases the previous implementation had a delay in full cleanup because it waited for the audio queue to be empty before stopping the player. This could cause issues in scenarios where immediate cleanup is required.

### Changes

  - Modified handleResourceCleanup function to accept an optional forceStop parameter
  - When forceStop is true, the player stops all audio immediately without waiting for the queue to empty
  - Updated the disconnect function to use this immediate cleanup option
