### PR TITLE
disconnect from call from the useVoiceClient hook when readyState is closed

### DIFF
--- a/packages/embed-react/package.json
+++ b/packages/embed-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed-react",
-  "version": "0.2.0-beta.6",
+  "version": "0.2.0-beta.7",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed",
-  "version": "0.2.0-beta.6",
+  "version": "0.2.0-beta.7",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-react",
-  "version": "0.2.0-beta.6",
+  "version": "0.2.0-beta.7",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -241,12 +241,12 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
 
   const { streamRef, getStream, permission: micPermission } = useEncoding();
 
-  // isClientDisconnected indicates that the websocket client disconnected
+  // isWebsocketDisconnected indicates that the websocket disconnected
   // in a way that was not initiated by the user (e.g. network error)
-  const [isClientDisconnected, setIsClientDisconnected] = useState(false);
+  const [isWebsocketDisconnected, setIsWebsocketDisconnected] = useState(false);
   useEffect(() => {
     if (
-      isClientDisconnected &&
+      isWebsocketDisconnected &&
       (player.queueLength === 0 || status.value === 'error')
     ) {
       handleResourceCleanup();
@@ -256,7 +256,7 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
     player.queueLength,
     player,
     status.value,
-    isClientDisconnected,
+    isWebsocketDisconnected,
     handleResourceCleanup,
     stopTimer,
   ]);
@@ -304,7 +304,7 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
       [updateError],
     ),
     onOpen: useCallback(() => {
-      setIsClientDisconnected(false);
+      setIsWebsocketDisconnected(false);
       startTimer();
       messageStore.createConnectMessage();
       props.onOpen?.();
@@ -320,8 +320,10 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
       [messageStore, stopTimer],
     ),
     onToolCall: props.onToolCall,
-    handleClientDisconnect: useCallback(() => {
-      setIsClientDisconnected(true);
+    handleWebsocketDisconnect: useCallback(() => {
+      // handleWebsocketDisconnect is called when the client disconnects
+      // without a user action to initiate the closure
+      setIsWebsocketDisconnected(true);
     }, []),
   });
 

--- a/packages/react/src/lib/useVoiceClient.ts
+++ b/packages/react/src/lib/useVoiceClient.ts
@@ -56,6 +56,7 @@ export const useVoiceClient = (props: {
   onClientError?: (message: string, error?: Error) => void;
   onOpen?: () => void;
   onClose?: Hume.empathicVoice.chat.ChatSocket.EventHandlers['close'];
+  disconnectFromCall: () => void;
 }) => {
   const client = useRef<Hume.empathicVoice.chat.ChatSocket | null>(null);
 
@@ -89,6 +90,11 @@ export const useVoiceClient = (props: {
 
   const onClose = useRef<typeof props.onClose>(props.onClose);
   onClose.current = props.onClose;
+
+  const disconnectFromCall = useRef<typeof props.disconnectFromCall>(
+    props.disconnectFromCall,
+  );
+  disconnectFromCall.current = props.disconnectFromCall;
 
   const connect = useCallback((config: SocketConfig) => {
     return new Promise((resolve, reject) => {
@@ -219,6 +225,7 @@ export const useVoiceClient = (props: {
   const sendSessionSettings = useCallback(
     (sessionSettings: Hume.empathicVoice.SessionSettings) => {
       if (readyState !== VoiceReadyState.OPEN) {
+        disconnectFromCall.current();
         return;
       }
       client.current?.sendSessionSettings(sessionSettings);
@@ -229,6 +236,7 @@ export const useVoiceClient = (props: {
   const sendAudio = useCallback(
     (arrayBuffer: ArrayBufferLike) => {
       if (readyState !== VoiceReadyState.OPEN) {
+        disconnectFromCall.current();
         return;
       }
       client.current?.socket?.send(arrayBuffer);
@@ -239,6 +247,7 @@ export const useVoiceClient = (props: {
   const sendUserInput = useCallback(
     (text: string) => {
       if (readyState !== VoiceReadyState.OPEN) {
+        disconnectFromCall.current();
         return;
       }
       client.current?.sendUserInput(text);
@@ -249,6 +258,7 @@ export const useVoiceClient = (props: {
   const sendAssistantInput = useCallback(
     (text: string) => {
       if (readyState !== VoiceReadyState.OPEN) {
+        disconnectFromCall.current();
         return;
       }
       client.current?.sendAssistantInput({
@@ -267,6 +277,7 @@ export const useVoiceClient = (props: {
         | Hume.empathicVoice.ToolErrorMessage,
     ) => {
       if (readyState !== VoiceReadyState.OPEN) {
+        disconnectFromCall.current();
         return;
       }
       if (toolMessage.type === 'tool_error') {

--- a/packages/react/src/lib/useVoiceClient.ts
+++ b/packages/react/src/lib/useVoiceClient.ts
@@ -56,7 +56,7 @@ export const useVoiceClient = (props: {
   onClientError?: (message: string, error?: Error) => void;
   onOpen?: () => void;
   onClose?: Hume.empathicVoice.chat.ChatSocket.EventHandlers['close'];
-  handleClientDisconnect: () => void;
+  handleWebsocketDisconnect: () => void;
 }) => {
   const client = useRef<Hume.empathicVoice.chat.ChatSocket | null>(null);
 
@@ -91,10 +91,10 @@ export const useVoiceClient = (props: {
   const onClose = useRef<typeof props.onClose>(props.onClose);
   onClose.current = props.onClose;
 
-  const handleClientDisconnect = useRef<typeof props.handleClientDisconnect>(
-    props.handleClientDisconnect,
-  );
-  handleClientDisconnect.current = props.handleClientDisconnect;
+  const handleWebsocketDisconnect = useRef<
+    typeof props.handleWebsocketDisconnect
+  >(props.handleWebsocketDisconnect);
+  handleWebsocketDisconnect.current = props.handleWebsocketDisconnect;
 
   const connect = useCallback((config: SocketConfig) => {
     return new Promise((resolve, reject) => {
@@ -225,7 +225,7 @@ export const useVoiceClient = (props: {
   const sendSessionSettings = useCallback(
     (sessionSettings: Hume.empathicVoice.SessionSettings) => {
       if (readyState !== VoiceReadyState.OPEN) {
-        handleClientDisconnect.current();
+        handleWebsocketDisconnect.current();
         return;
       }
       client.current?.sendSessionSettings(sessionSettings);
@@ -236,7 +236,7 @@ export const useVoiceClient = (props: {
   const sendAudio = useCallback(
     (arrayBuffer: ArrayBufferLike) => {
       if (readyState !== VoiceReadyState.OPEN) {
-        handleClientDisconnect.current();
+        handleWebsocketDisconnect.current();
         return;
       }
       client.current?.socket?.send(arrayBuffer);
@@ -247,7 +247,7 @@ export const useVoiceClient = (props: {
   const sendUserInput = useCallback(
     (text: string) => {
       if (readyState !== VoiceReadyState.OPEN) {
-        handleClientDisconnect.current();
+        handleWebsocketDisconnect.current();
         return;
       }
       client.current?.sendUserInput(text);
@@ -258,7 +258,7 @@ export const useVoiceClient = (props: {
   const sendAssistantInput = useCallback(
     (text: string) => {
       if (readyState !== VoiceReadyState.OPEN) {
-        handleClientDisconnect.current();
+        handleWebsocketDisconnect.current();
         return;
       }
       client.current?.sendAssistantInput({
@@ -277,7 +277,7 @@ export const useVoiceClient = (props: {
         | Hume.empathicVoice.ToolErrorMessage,
     ) => {
       if (readyState !== VoiceReadyState.OPEN) {
-        handleClientDisconnect.current();
+        handleWebsocketDisconnect.current();
         return;
       }
       if (toolMessage.type === 'tool_error') {

--- a/packages/react/src/lib/useVoiceClient.ts
+++ b/packages/react/src/lib/useVoiceClient.ts
@@ -56,7 +56,7 @@ export const useVoiceClient = (props: {
   onClientError?: (message: string, error?: Error) => void;
   onOpen?: () => void;
   onClose?: Hume.empathicVoice.chat.ChatSocket.EventHandlers['close'];
-  disconnectFromCall: () => void;
+  handleClientDisconnect: () => void;
 }) => {
   const client = useRef<Hume.empathicVoice.chat.ChatSocket | null>(null);
 
@@ -91,10 +91,10 @@ export const useVoiceClient = (props: {
   const onClose = useRef<typeof props.onClose>(props.onClose);
   onClose.current = props.onClose;
 
-  const disconnectFromCall = useRef<typeof props.disconnectFromCall>(
-    props.disconnectFromCall,
+  const handleClientDisconnect = useRef<typeof props.handleClientDisconnect>(
+    props.handleClientDisconnect,
   );
-  disconnectFromCall.current = props.disconnectFromCall;
+  handleClientDisconnect.current = props.handleClientDisconnect;
 
   const connect = useCallback((config: SocketConfig) => {
     return new Promise((resolve, reject) => {
@@ -225,7 +225,7 @@ export const useVoiceClient = (props: {
   const sendSessionSettings = useCallback(
     (sessionSettings: Hume.empathicVoice.SessionSettings) => {
       if (readyState !== VoiceReadyState.OPEN) {
-        disconnectFromCall.current();
+        handleClientDisconnect.current();
         return;
       }
       client.current?.sendSessionSettings(sessionSettings);
@@ -236,7 +236,7 @@ export const useVoiceClient = (props: {
   const sendAudio = useCallback(
     (arrayBuffer: ArrayBufferLike) => {
       if (readyState !== VoiceReadyState.OPEN) {
-        disconnectFromCall.current();
+        handleClientDisconnect.current();
         return;
       }
       client.current?.socket?.send(arrayBuffer);
@@ -247,7 +247,7 @@ export const useVoiceClient = (props: {
   const sendUserInput = useCallback(
     (text: string) => {
       if (readyState !== VoiceReadyState.OPEN) {
-        disconnectFromCall.current();
+        handleClientDisconnect.current();
         return;
       }
       client.current?.sendUserInput(text);
@@ -258,7 +258,7 @@ export const useVoiceClient = (props: {
   const sendAssistantInput = useCallback(
     (text: string) => {
       if (readyState !== VoiceReadyState.OPEN) {
-        disconnectFromCall.current();
+        handleClientDisconnect.current();
         return;
       }
       client.current?.sendAssistantInput({
@@ -277,7 +277,7 @@ export const useVoiceClient = (props: {
         | Hume.empathicVoice.ToolErrorMessage,
     ) => {
       if (readyState !== VoiceReadyState.OPEN) {
-        disconnectFromCall.current();
+        handleClientDisconnect.current();
         return;
       }
       if (toolMessage.type === 'tool_error') {


### PR DESCRIPTION
* PR moves resource cleanup out of the onClose handler. instead of tracking all the various different ways a websocket could close, there's now a binary situation of "user intiated the closure" or "server shut down the socket connection". for the latter case, there is now a separate callback (`handleWebsocketDisconnect`) which will run and clean up resources. It also makes sure the audio queue is emptied before cleaning things up.
* Also consolidates resource cleanup so that the audio player and mic are shut down at the same time.