### PR TITLE
add `reason` field to `VoiceError`

### DIFF
--- a/packages/embed-react/package.json
+++ b/packages/embed-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed-react",
-  "version": "0.2.0-beta.8",
+  "version": "0.2.0-beta.9",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed",
-  "version": "0.2.0-beta.8",
+  "version": "0.2.0-beta.9",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-react",
-  "version": "0.2.0-beta.8",
+  "version": "0.2.0-beta.9",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -35,10 +35,20 @@ import {
   UserTranscriptMessage,
 } from '../models/messages';
 
+export type MicErrorReason =
+  | 'mic_initialization_error'
+  | 'mic_closure_error'
+  | 'mime_types_not_supported';
+
 type VoiceError =
   | { type: 'socket_error'; message: string; error?: Error }
   | { type: 'audio_error'; message: string; error?: Error }
-  | { type: 'mic_error'; message: string; error?: Error };
+  | {
+      type: 'mic_error';
+      reason: MicErrorReason;
+      message: string;
+      error?: Error;
+    };
 
 type VoiceStatus =
   | {
@@ -271,8 +281,10 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
         micStartFnRef.current?.(stream);
       })
       .catch((e) => {
+        console.log('e', e);
         const error: VoiceError = {
           type: 'mic_error',
+          reason: 'mic_initialization_error',
           message:
             e instanceof Error
               ? e.message
@@ -457,8 +469,8 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
       [clientSendAudio, updateError],
     ),
     onError: useCallback(
-      (message) => {
-        updateError({ type: 'mic_error', message });
+      (message, reason) => {
+        updateError({ type: 'mic_error', reason, message });
       },
       [updateError],
     ),

--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -42,23 +42,16 @@ export type SocketErrorReason =
   | 'received_assistant_error_message'
   | 'received_tool_call_error';
 
-export type AudioPlayerError =
-  | 'audio_player_initialization_error'
-  | 'audio_worklet_load_failure'
-  | 'audio_player_not_initialized'
-  | 'malformed_audio'
-  | 'audio_player_closure_error';
-
 export type AudioPlayerErrorReason =
-  | 'audio_player_initialization_error'
+  | 'audio_player_initialization_failure'
   | 'audio_worklet_load_failure'
   | 'audio_player_not_initialized'
   | 'malformed_audio'
-  | 'audio_player_closure_error';
+  | 'audio_player_closure_failure';
 
 export type MicErrorReason =
-  | 'mic_initialization_error'
-  | 'mic_closure_error'
+  | 'mic_initialization_failure'
+  | 'mic_closure_failure'
   | 'mime_types_not_supported';
 
 type VoiceError =
@@ -320,7 +313,7 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
         console.log('e', e);
         const error: VoiceError = {
           type: 'mic_error',
-          reason: 'mic_initialization_error',
+          reason: 'mic_initialization_failure',
           message:
             e instanceof Error
               ? e.message
@@ -336,7 +329,7 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
     } catch (e) {
       const error: VoiceError = {
         type: 'audio_error',
-        reason: 'audio_player_initialization_error',
+        reason: 'audio_player_initialization_failure',
         message:
           e instanceof Error
             ? e.message

--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -310,7 +310,6 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
         micStartFnRef.current?.(stream);
       })
       .catch((e) => {
-        console.log('e', e);
         const error: VoiceError = {
           type: 'mic_error',
           reason: 'mic_initialization_failure',

--- a/packages/react/src/lib/useGetMicrophoneStream.ts
+++ b/packages/react/src/lib/useGetMicrophoneStream.ts
@@ -11,18 +11,19 @@ export const useGetMicrophoneStream = () => {
 
   const getStream = useCallback(
     async (audioConstraints: AudioConstraints = {}) => {
+      let stream;
       try {
-        const stream = await getAudioStream(audioConstraints);
-
-        setPermission('granted');
-
-        checkForAudioTracks(stream);
-
-        return stream;
+        stream = await getAudioStream(audioConstraints);
       } catch (e) {
         setPermission('denied');
         throw e;
       }
+
+      setPermission('granted');
+
+      checkForAudioTracks(stream);
+
+      return stream;
     },
     [],
   );

--- a/packages/react/src/lib/useMicrophone.ts
+++ b/packages/react/src/lib/useMicrophone.ts
@@ -6,12 +6,13 @@ import type { MeydaFeaturesObject } from 'meyda';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { generateEmptyFft } from './generateEmptyFft';
+import type { MicErrorReason } from './VoiceProvider';
 
 export type MicrophoneProps = {
   onAudioCaptured: (b: ArrayBuffer) => void;
   onStartRecording?: () => void;
   onStopRecording?: () => void;
-  onError: (message: string) => void;
+  onError: (message: string, reason: MicErrorReason) => void;
 };
 
 export const useMicrophone = (props: MicrophoneProps) => {
@@ -117,7 +118,7 @@ export const useMicrophone = (props: MicrophoneProps) => {
       setIsMuted(false);
     } catch (e) {
       const message = e instanceof Error ? e.message : 'Unknown error';
-      onError(`Error stopping microphone: ${message}`);
+      onError(`Error stopping microphone: ${message}`, 'mic_closure_error');
       console.log(e);
       void true;
     }
@@ -175,7 +176,7 @@ export const useMicrophone = (props: MicrophoneProps) => {
     if (mimeTypeResult.success) {
       mimeTypeRef.current = mimeTypeResult.mimeType;
     } else {
-      onError(mimeTypeResult.error.message);
+      onError(mimeTypeResult.error.message, 'mime_types_not_supported');
     }
   }, [onError]);
 

--- a/packages/react/src/lib/useMicrophone.ts
+++ b/packages/react/src/lib/useMicrophone.ts
@@ -118,7 +118,7 @@ export const useMicrophone = (props: MicrophoneProps) => {
       setIsMuted(false);
     } catch (e) {
       const message = e instanceof Error ? e.message : 'Unknown error';
-      onError(`Error stopping microphone: ${message}`, 'mic_closure_error');
+      onError(`Error stopping microphone: ${message}`, 'mic_closure_failure');
       console.log(e);
       void true;
     }

--- a/packages/react/src/lib/useMicrophone.ts
+++ b/packages/react/src/lib/useMicrophone.ts
@@ -119,7 +119,6 @@ export const useMicrophone = (props: MicrophoneProps) => {
     } catch (e) {
       const message = e instanceof Error ? e.message : 'Unknown error';
       onError(`Error stopping microphone: ${message}`, 'mic_closure_failure');
-      console.log(e);
       void true;
     }
   }, [dataHandler, onError]);

--- a/packages/react/src/lib/useSoundPlayer.ts
+++ b/packages/react/src/lib/useSoundPlayer.ts
@@ -126,7 +126,7 @@ export const useSoundPlayer = (props: {
     } catch (e) {
       onError.current(
         'Failed to initialize audio player',
-        'audio_player_initialization_error',
+        'audio_player_initialization_failure',
       );
     }
   }, [loadAudioWorklet]);

--- a/packages/react/src/lib/useSoundPlayer.ts
+++ b/packages/react/src/lib/useSoundPlayer.ts
@@ -4,10 +4,11 @@ import z from 'zod';
 
 import { convertLinearFrequenciesToBark } from './convertFrequencyScale';
 import { generateEmptyFft } from './generateEmptyFft';
+import type { AudioPlayerErrorReason } from './VoiceProvider';
 import type { AudioOutputMessage } from '../models/messages';
 
 export const useSoundPlayer = (props: {
-  onError: (message: string) => void;
+  onError: (message: string, reason: AudioPlayerErrorReason) => void;
   onPlayAudio: (id: string) => void;
   onStopAudio: (id: string) => void;
 }) => {
@@ -73,7 +74,10 @@ export const useSoundPlayer = (props: {
 
       const isWorkletLoaded = await loadAudioWorklet(initAudioContext);
       if (!isWorkletLoaded) {
-        onError.current('Failed to load audio worklet');
+        onError.current(
+          'Failed to load audio worklet',
+          'audio_worklet_load_failure',
+        );
         return;
       }
 
@@ -120,13 +124,19 @@ export const useSoundPlayer = (props: {
 
       isInitialized.current = true;
     } catch (e) {
-      onError.current('Failed to initialize audio player');
+      onError.current(
+        'Failed to initialize audio player',
+        'audio_player_initialization_error',
+      );
     }
   }, [loadAudioWorklet]);
 
   const addToQueue = useCallback(async (message: AudioOutputMessage) => {
     if (!isInitialized.current || !audioContext.current) {
-      onError.current('Audio player has not been initialized');
+      onError.current(
+        'Audio player has not been initialized',
+        'audio_player_not_initialized',
+      );
       return;
     }
 
@@ -143,7 +153,10 @@ export const useSoundPlayer = (props: {
       onPlayAudio.current(message.id);
     } catch (e) {
       const eMessage = e instanceof Error ? e.message : 'Unknown error';
-      onError.current(`Failed to add clip to queue: ${eMessage}`);
+      onError.current(
+        `Failed to add clip to queue: ${eMessage}`,
+        'malformed_audio',
+      );
     }
   }, []);
 


### PR DESCRIPTION
Add reason field so it's easier for the end user to know why the error happened. Example use case: if microphone permission is denied, we would want to show a different UI state than if the mic failed to stop. User can check the `reason` field to update the UI accordingly