### PR TITLE
Enable alternative to worklet, regular buffer

### DIFF
--- a/examples/next-app/components/Voice.tsx
+++ b/examples/next-app/components/Voice.tsx
@@ -1,143 +1,165 @@
 'use client';
 import type { ToolCallHandler } from '@humeai/voice-react';
 import { VoiceProvider } from '@humeai/voice-react';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { z } from 'zod';
 
 import { ExampleComponent } from '@/components/ExampleComponent';
 
 export const Voice = ({ accessToken }: { accessToken: string }) => {
+  const [enableAudioWorklet, setEnableAudioWorklet] = useState(true);
+
   return (
-    <VoiceProvider
-      auth={{ type: 'accessToken', value: accessToken }}
-      hostname={process.env.NEXT_PUBLIC_HUME_VOICE_HOSTNAME || 'api.hume.ai'}
-      messageHistoryLimit={10}
-      onMessage={(message) => {
-        // eslint-disable-next-line no-console
-        console.log('message', message);
-      }}
-      onError={(message) => {
-        // eslint-disable-next-line no-console
-        console.log('onError', message);
-      }}
-      onAudioStart={(clipId) => {
-        // eslint-disable-next-line no-console
-        console.log('Start playing clip with ID:', clipId);
-      }}
-      onAudioEnd={(clipId) => {
-        // eslint-disable-next-line no-console
-        console.log('Stop playing clip with ID:', clipId);
-      }}
-      onInterruption={(message) => {
-        // eslint-disable-next-line no-console
-        console.log('Interruption triggered on the following message', message);
-      }}
-      onToolCall={useCallback<ToolCallHandler>(async (toolCall, response) => {
-        if (toolCall.name === 'weather_tool') {
-          try {
-            const args = z
-              .object({
-                location: z.string(),
-                format: z.enum(['fahrenheit', 'celsius']),
-              })
-              .safeParse(JSON.parse(toolCall.parameters));
+    <>
+      <div className="flex py-4">
+        <label>
+          <input
+            className="mr-2"
+            type="checkbox"
+            checked={enableAudioWorklet}
+            onChange={(val) => {
+              setEnableAudioWorklet(val.target.checked);
+            }}
+          />
+          Enable audio worklet
+        </label>
+      </div>
 
-            if (args.success === false) {
-              throw new Error(
-                'Tool response did not match the expected weather tool schema',
+      <VoiceProvider
+        auth={{ type: 'accessToken', value: accessToken }}
+        hostname={process.env.NEXT_PUBLIC_HUME_VOICE_HOSTNAME || 'api.hume.ai'}
+        messageHistoryLimit={10}
+        enableAudioWorklet={enableAudioWorklet}
+        onMessage={(message) => {
+          // eslint-disable-next-line no-console
+          console.log('message', message);
+        }}
+        onError={(message) => {
+          // eslint-disable-next-line no-console
+          console.log('onError', message);
+        }}
+        onAudioStart={(clipId) => {
+          // eslint-disable-next-line no-console
+          console.log('Start playing clip with ID:', clipId);
+        }}
+        onAudioEnd={(clipId) => {
+          // eslint-disable-next-line no-console
+          console.log('Stop playing clip with ID:', clipId);
+        }}
+        onInterruption={(message) => {
+          // eslint-disable-next-line no-console
+          console.log(
+            'Interruption triggered on the following message',
+            message,
+          );
+        }}
+        onToolCall={useCallback<ToolCallHandler>(async (toolCall, response) => {
+          if (toolCall.name === 'weather_tool') {
+            try {
+              const args = z
+                .object({
+                  location: z.string(),
+                  format: z.enum(['fahrenheit', 'celsius']),
+                })
+                .safeParse(JSON.parse(toolCall.parameters));
+
+              if (args.success === false) {
+                throw new Error(
+                  'Tool response did not match the expected weather tool schema',
+                );
+              }
+
+              const location: unknown = await fetch(
+                `https://geocode.maps.co/search?q=${String(args.data.location)}&api_key=${process.env.NEXT_PUBLIC_GEOCODE_API_KEY}`,
+              ).then((res) => res.json());
+
+              const locationResults = z
+                .array(
+                  z.object({
+                    lat: z.string(),
+                    lon: z.string(),
+                  }),
+                )
+                .safeParse(location);
+
+              if (locationResults.success === false) {
+                throw new Error(
+                  'Location results did not match the expected schema',
+                );
+              }
+              const { lat, lon } = locationResults.data[0];
+              const pointMetadataEndpoint: string = `https://api.weather.gov/points/${parseFloat(lat).toFixed(3)},${parseFloat(lon).toFixed(3)}`;
+
+              const result: unknown = await fetch(pointMetadataEndpoint, {
+                method: 'GET',
+              }).then((res) => res.json());
+
+              const json = z
+                .object({
+                  properties: z.object({
+                    forecast: z.string(),
+                  }),
+                })
+                .safeParse(result);
+              if (json.success === false) {
+                throw new Error(
+                  'Point metadata did not match the expected schema',
+                );
+              }
+              const { properties } = json.data;
+              const { forecast: forecastUrl } = properties;
+
+              const forecastResult: unknown = await fetch(forecastUrl).then(
+                (res) => res.json(),
               );
+
+              const forecastJson = z
+                .object({
+                  properties: z.object({
+                    periods: z.array(z.unknown()),
+                  }),
+                })
+                .safeParse(forecastResult);
+              if (forecastJson.success === false) {
+                throw new Error('Forecast did not match the expected schema');
+              }
+              const forecast = forecastJson.data.properties.periods;
+
+              return response.success(forecast);
+            } catch (error) {
+              return response.error({
+                error: 'Weather tool error',
+                code: 'weather_tool_error',
+                level: 'error',
+                content: 'There was an error with the weather tool',
+              });
             }
-
-            const location: unknown = await fetch(
-              `https://geocode.maps.co/search?q=${String(args.data.location)}&api_key=${process.env.NEXT_PUBLIC_GEOCODE_API_KEY}`,
-            ).then((res) => res.json());
-
-            const locationResults = z
-              .array(
-                z.object({
-                  lat: z.string(),
-                  lon: z.string(),
-                }),
-              )
-              .safeParse(location);
-
-            if (locationResults.success === false) {
-              throw new Error(
-                'Location results did not match the expected schema',
-              );
-            }
-            const { lat, lon } = locationResults.data[0];
-            const pointMetadataEndpoint: string = `https://api.weather.gov/points/${parseFloat(lat).toFixed(3)},${parseFloat(lon).toFixed(3)}`;
-
-            const result: unknown = await fetch(pointMetadataEndpoint, {
-              method: 'GET',
-            }).then((res) => res.json());
-
-            const json = z
-              .object({
-                properties: z.object({
-                  forecast: z.string(),
-                }),
-              })
-              .safeParse(result);
-            if (json.success === false) {
-              throw new Error(
-                'Point metadata did not match the expected schema',
-              );
-            }
-            const { properties } = json.data;
-            const { forecast: forecastUrl } = properties;
-
-            const forecastResult: unknown = await fetch(forecastUrl).then(
-              (res) => res.json(),
-            );
-
-            const forecastJson = z
-              .object({
-                properties: z.object({
-                  periods: z.array(z.unknown()),
-                }),
-              })
-              .safeParse(forecastResult);
-            if (forecastJson.success === false) {
-              throw new Error('Forecast did not match the expected schema');
-            }
-            const forecast = forecastJson.data.properties.periods;
-
-            return response.success(forecast);
-          } catch (error) {
+          } else {
             return response.error({
-              error: 'Weather tool error',
-              code: 'weather_tool_error',
-              level: 'error',
-              content: 'There was an error with the weather tool',
+              error: 'Tool not found',
+              code: 'tool_not_found',
+              level: 'warning',
+              content: 'The tool you requested was not found',
             });
           }
-        } else {
-          return response.error({
-            error: 'Tool not found',
-            code: 'tool_not_found',
-            level: 'warning',
-            content: 'The tool you requested was not found',
-          });
-        }
-      }, [])}
-      configId={process.env.NEXT_PUBLIC_HUME_VOICE_WEATHER_CONFIG_ID}
-      onClose={(event) => {
-        const niceClosure = 1000;
-        const code = event.code;
+        }, [])}
+        configId={process.env.NEXT_PUBLIC_HUME_VOICE_WEATHER_CONFIG_ID}
+        onClose={(event) => {
+          const niceClosure = 1000;
+          const code = event.code;
 
-        if (code !== niceClosure) {
-          // eslint-disable-next-line no-console
-          console.error('close event was not nice', event);
-        }
-      }}
-      sessionSettings={{
-        type: 'session_settings',
-        builtinTools: [{ name: 'web_search' }],
-      }}
-    >
-      <ExampleComponent />
-    </VoiceProvider>
+          if (code !== niceClosure) {
+            // eslint-disable-next-line no-console
+            console.error('close event was not nice', event);
+          }
+        }}
+        sessionSettings={{
+          type: 'session_settings',
+          builtinTools: [{ name: 'web_search' }],
+        }}
+      >
+        <ExampleComponent />
+      </VoiceProvider>
+    </>
   );
 };

--- a/packages/embed-react/package.json
+++ b/packages/embed-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed-react",
-  "version": "0.2.0-beta.11",
+  "version": "0.2.0-beta.12",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed",
-  "version": "0.2.0-beta.11",
+  "version": "0.2.0-beta.12",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-react",
-  "version": "0.2.0-beta.11",
+  "version": "0.2.0-beta.12",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -247,6 +247,7 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
   const micStopFnRef = useRef<null | (() => void)>(null);
 
   const player = useSoundPlayer({
+    enableAudioWorklet: false,
     onError: (message, reason) => {
       updateError({ type: 'audio_error', reason, message });
     },

--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -247,7 +247,7 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
   const micStopFnRef = useRef<null | (() => void)>(null);
 
   const player = useSoundPlayer({
-    enableAudioWorklet: false,
+    enableAudioWorklet: true,
     onError: (message, reason) => {
       updateError({ type: 'audio_error', reason, message });
     },

--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -348,6 +348,7 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
         error,
         messageStore,
         player,
+        stopStream,
         stopTimer,
         toolStatus,
       ],
@@ -514,6 +515,7 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
   }, [
     client,
     player,
+    stopStream,
     mic,
     clearMessagesOnDisconnect,
     toolStatus,

--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -154,6 +154,7 @@ export type VoiceProviderProps = PropsWithChildren<
    * @description The maximum number of messages to keep in memory.
    */
   messageHistoryLimit?: number;
+  enableAudioWorklet?: boolean;
 };
 
 export const useVoice = () => {
@@ -170,6 +171,7 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
   messageHistoryLimit = 100,
   sessionSettings,
   verboseTranscription = true,
+  enableAudioWorklet = true,
   ...props
 }) => {
   const {
@@ -247,7 +249,7 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
   const micStopFnRef = useRef<null | (() => void)>(null);
 
   const player = useSoundPlayer({
-    enableAudioWorklet: true,
+    enableAudioWorklet,
     onError: (message, reason) => {
       updateError({ type: 'audio_error', reason, message });
     },

--- a/packages/react/src/lib/useSoundPlayer.test.ts
+++ b/packages/react/src/lib/useSoundPlayer.test.ts
@@ -15,6 +15,7 @@ describe('useSoundPlayer', () => {
         onError: mockOnError,
         onPlayAudio: mockOnPlayAudio,
         onStopAudio: mockOnStopAudio,
+        enableAudioWorklet: true,
       }),
     );
 

--- a/packages/react/src/lib/useSoundPlayer.ts
+++ b/packages/react/src/lib/useSoundPlayer.ts
@@ -6,6 +6,7 @@ import { convertLinearFrequenciesToBark } from './convertFrequencyScale';
 import { generateEmptyFft } from './generateEmptyFft';
 import type { AudioPlayerErrorReason } from './VoiceProvider';
 import type { AudioOutputMessage } from '../models/messages';
+import { loadAudioWorklet } from '../utils/loadAudioWorklet';
 
 export const useSoundPlayer = (props: {
   enableAudioWorklet: boolean;
@@ -134,28 +135,6 @@ export const useSoundPlayer = (props: {
     };
   }, []);
 
-  /*
-   * Only for AudioWorklet mode, obviously.
-   */
-  const loadAudioWorklet = useCallback(
-    async (ctx: AudioContext, attemptNumber = 1): Promise<boolean> => {
-      return ctx.audioWorklet
-        .addModule(
-          'https://storage.googleapis.com/evi-react-sdk-assets/audio-worklet-20250507.js',
-        )
-        .then(() => {
-          return true;
-        })
-        .catch(() => {
-          if (attemptNumber >= 10) {
-            return false;
-          }
-          return loadAudioWorklet(ctx, attemptNumber + 1);
-        });
-    },
-    [],
-  );
-
   const initPlayer = useCallback(async () => {
     try {
       const initAudioContext = new AudioContext();
@@ -230,7 +209,7 @@ export const useSoundPlayer = (props: {
         'audio_player_initialization_failure',
       );
     }
-  }, [loadAudioWorklet, props.enableAudioWorklet]);
+  }, [props.enableAudioWorklet]);
 
   const addToQueue = useCallback(
     async (message: AudioOutputMessage) => {

--- a/packages/react/src/utils/loadAudioWorklet.ts
+++ b/packages/react/src/utils/loadAudioWorklet.ts
@@ -1,0 +1,18 @@
+export const loadAudioWorklet = async (
+  ctx: AudioContext,
+  attemptNumber = 1,
+): Promise<boolean> => {
+  return ctx.audioWorklet
+    .addModule(
+      'https://storage.googleapis.com/evi-react-sdk-assets/audio-worklet-20250507.js',
+    )
+    .then(() => {
+      return true;
+    })
+    .catch(() => {
+      if (attemptNumber >= 10) {
+        return false;
+      }
+      return loadAudioWorklet(ctx, attemptNumber + 1);
+    });
+};


### PR DESCRIPTION
### Changes

This PR introduces the following enhancements:

  - Implements a dual approach to audio processing:
    - AudioWorklet Mode (default): Uses a separate thread for audio processing via AudioWorkletNode
    - Regular Buffer Mode: Falls back to AudioBufferSourceNode in the main thread if worklets aren't available
  - Adds a new configurable prop enableAudioWorklet to the VoiceProvider component (defaults to true)
  - Restores the implementation for audio clip queuing and playback in both modes from 0.1.22

The implementation allows clients to control whether they want to use the AudioWorklet mode or the traditional buffer-based mode.