### PR TITLE
ensure microphone stream is stopped during disconnect

### DIFF
--- a/examples/next-app/components/ExampleComponent.tsx
+++ b/examples/next-app/components/ExampleComponent.tsx
@@ -290,11 +290,20 @@ export const ExampleComponent = () => {
             .with('connecting', () => (
               <>
                 {callDuration}
+
                 <button
                   className="cursor-not-allowed rounded border border-neutral-500 p-2"
                   disabled
                 >
                   Connecting...
+                </button>
+                <button
+                  className="rounded border border-red-500 p-2 text-red-500"
+                  onClick={() => {
+                    disconnect();
+                  }}
+                >
+                  Disconnect
                 </button>
               </>
             ))

--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -259,7 +259,7 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
     },
   });
 
-  const { getStream } = useGetMicrophoneStream();
+  const { getStream, stopStream } = useGetMicrophoneStream();
 
   const client = useVoiceClient({
     onAudioMessage: (message: AudioOutputMessage) => {
@@ -327,6 +327,7 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
         stopTimer();
         messageStore.createDisconnectMessage(event);
         player.stopAll();
+        stopStream();
         micStopFnRef.current?.();
         if (clearMessagesOnDisconnect) {
           messageStore.clearMessages();
@@ -498,6 +499,9 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
       client.disconnect();
     }
     player.stopAll();
+    // call stopStream separately because the user could stop the
+    // the connection before the microphone is initialized
+    stopStream();
     mic.stop();
     if (clearMessagesOnDisconnect) {
       messageStore.clearMessages();

--- a/packages/react/src/lib/useGetMicrophoneStream.ts
+++ b/packages/react/src/lib/useGetMicrophoneStream.ts
@@ -1,6 +1,6 @@
 // cspell:ignore dataavailable
 import { checkForAudioTracks, getAudioStream } from 'hume';
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 import type { AudioConstraints } from '../models/connect-options';
 
@@ -8,6 +8,7 @@ type PermissionStatus = 'prompt' | 'granted' | 'denied';
 
 export const useGetMicrophoneStream = () => {
   const [permission, setPermission] = useState<PermissionStatus>('prompt');
+  const currentStream = useRef<MediaStream | null>(null);
 
   const getStream = useCallback(
     async (audioConstraints: AudioConstraints = {}) => {
@@ -29,13 +30,23 @@ export const useGetMicrophoneStream = () => {
 
       checkForAudioTracks(stream);
 
+      currentStream.current = stream;
+
       return stream;
     },
     [],
   );
 
+  const stopStream = useCallback(() => {
+    if (currentStream.current) {
+      currentStream.current.getTracks().forEach((track) => track.stop());
+      currentStream.current = null;
+    }
+  }, []);
+
   return {
     getStream,
+    stopStream,
     permission,
   };
 };


### PR DESCRIPTION
currently, the order of operations for a call is as follows:
1. we get the microphone stream so we can check for permissions
2. we connect to the websocket
3. we initialize the mic and audio player

the user can potentially disconnect the call during step 2, while the socket is connecting but the mic has not yet been initialized. if this happens, the stream never gets cleaned up. therefore, in this PR, we add a separate stopSteam function that cleans up the stream on disconnect.