### PR TITLE
move queue length check before audio context check

### DIFF
--- a/packages/embed-react/package.json
+++ b/packages/embed-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed-react",
-  "version": "0.2.0-beta.12",
+  "version": "0.2.0-beta.13",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed",
-  "version": "0.2.0-beta.12",
+  "version": "0.2.0-beta.13",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-react",
-  "version": "0.2.0-beta.12",
+  "version": "0.2.0-beta.13",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/src/lib/useSoundPlayer.ts
+++ b/packages/react/src/lib/useSoundPlayer.ts
@@ -62,16 +62,16 @@ export const useSoundPlayer = (props: {
    * It will play the next clip in the queue if there is one.
    */
   const playNextClip = useCallback(() => {
+    if (clipQueue.current.length === 0 || isProcessing.current) {
+      setQueueLength(0);
+      return;
+    }
+
     if (analyserNode.current === null || audioContext.current === null) {
       onError.current(
         'Audio player is not initialized',
         'audio_player_initialization_failure',
       );
-      return;
-    }
-
-    if (clipQueue.current.length === 0 || isProcessing.current) {
-      setQueueLength(0);
       return;
     }
 


### PR DESCRIPTION
Swaps the order of these two if statements in playNextClip. If the queue is empty, then we know we can return from the function safely and it doesn't matter if the audio context is no longer initialized. This helps address a rare race condition where the user disconnects the call immediately before an audio buffer ends.