### PR TITLE
guard against double connection attempt

### DIFF
--- a/packages/embed-react/package.json
+++ b/packages/embed-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed-react",
-  "version": "0.2.0-beta.13",
+  "version": "0.2.0-beta.14",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed",
-  "version": "0.2.0-beta.13",
+  "version": "0.2.0-beta.14",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-react",
-  "version": "0.2.0-beta.13",
+  "version": "0.2.0-beta.14",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -183,6 +183,7 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
   const [status, setStatus] = useState<VoiceStatus>({
     value: 'disconnected',
   });
+  const isConnectingRef = useRef(false);
 
   const [isPaused, setIsPaused] = useState(false);
 
@@ -427,8 +428,17 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
 
   const connect = useCallback(
     async (options: ConnectOptions = {}) => {
+      if (isConnectingRef.current || status.value === 'connected') {
+        console.warn(
+          'Already connected or connecting to a chat. Ignoring duplicate connection attempt.',
+        );
+
+        return;
+      }
+
       updateError(null);
       setStatus({ value: 'connecting' });
+      isConnectingRef.current = true;
 
       let stream: MediaStream | null = null;
       try {
@@ -493,9 +503,10 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
         playerPromise.status === 'fulfilled'
       ) {
         setStatus({ value: 'connected' });
+        isConnectingRef.current = false;
       }
     },
-    [client, config, getStream, mic, player, updateError],
+    [client, config, getStream, mic, player, status.value, updateError],
   );
 
   const disconnectFromVoice = useCallback(() => {

--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -433,7 +433,6 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
         console.warn(
           'Already connected or connecting to a chat. Ignoring duplicate connection attempt.',
         );
-
         return;
       }
 
@@ -467,11 +466,12 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
           verboseTranscription: true,
         });
       } catch (e) {
-        // catching the thrown error here so we can return early from the connect function,
-        // but the error itself is handled in the `onClientError` callback on the client
+        // catching the thrown error here so we can return early from the connect function.
+        // Any errors themselves are handled in the `onClientError` callback on the client,
+        // except for the AbortController case, which we don't need to call onClientError for
+        // because cancellations are intentional, and not network errors.
         return;
       }
-
       const [micPromise, playerPromise] = await Promise.allSettled([
         mic.start(stream),
         player.initPlayer(),
@@ -516,6 +516,7 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
     if (client.readyState !== VoiceReadyState.CLOSED) {
       client.disconnect();
     }
+
     player.stopAll();
     // call stopStream separately because the user could stop the
     // the connection before the microphone is initialized

--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -329,6 +329,7 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
         // onClose handler needs to handle resource cleanup in the event that the
         // websocket connection is closed by the server and not the user/client
         stopTimer();
+        isConnectingRef.current = false;
         messageStore.createDisconnectMessage(event);
         player.stopAll();
         stopStream();
@@ -510,6 +511,8 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
   );
 
   const disconnectFromVoice = useCallback(() => {
+    isConnectingRef.current = false;
+
     if (client.readyState !== VoiceReadyState.CLOSED) {
       client.disconnect();
     }


### PR DESCRIPTION
Two updates to prevent double connection issues:
1. prevent consumer from initializing resources again if the chat is already connected or connecting (e.g. user calls `connect` twice in a row without calling `disconnect` on the first attempt)
2. add AbortController to the websocket client so the connection attempt is canceled (e.g. the user calls `connect`, and then calls `disconnect` before the connection is established)