### PR TITLE
harden against resource setup/cleanup race conditions

### DIFF
--- a/packages/embed-react/package.json
+++ b/packages/embed-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed-react",
-  "version": "0.2.0-beta.14",
+  "version": "0.2.0-beta.15",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed",
-  "version": "0.2.0-beta.14",
+  "version": "0.2.0-beta.15",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/.eslintrc.js
+++ b/packages/react/.eslintrc.js
@@ -21,5 +21,6 @@ module.exports = {
   rules: {
     'no-console': 'off',
     'no-unused-vars': 'off',
+    '@typescript-eslint/no-floating-promises': 'error',
   },
 };

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-react",
-  "version": "0.2.0-beta.14",
+  "version": "0.2.0-beta.15",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -297,15 +297,6 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
     },
     onMessage: useCallback(
       (message: JSONMessage) => {
-        if (
-          resourceStatusRef.current.audioPlayer === 'disconnecting' ||
-          resourceStatusRef.current.audioPlayer === 'disconnected'
-        ) {
-          // disconnection in progress, and resources are being cleaned up.
-          // ignore the message
-          return;
-        }
-
         // store message
         messageStore.onMessage(message);
 

--- a/packages/react/src/lib/useMicrophone.ts
+++ b/packages/react/src/lib/useMicrophone.ts
@@ -89,7 +89,7 @@ export const useMicrophone = (props: MicrophoneProps) => {
     [dataHandler, mimeTypeRef],
   );
 
-  const stop = useCallback(() => {
+  const stop = useCallback(async () => {
     try {
       if (currentAnalyzer.current) {
         currentAnalyzer.current.stop();
@@ -97,7 +97,7 @@ export const useMicrophone = (props: MicrophoneProps) => {
       }
 
       if (audioContext.current) {
-        void audioContext.current
+        await audioContext.current
           .close()
           .then(() => {
             audioContext.current = null;

--- a/packages/react/src/lib/useSoundPlayer.ts
+++ b/packages/react/src/lib/useSoundPlayer.ts
@@ -261,7 +261,7 @@ export const useSoundPlayer = (props: {
     [playNextClip, props.enableAudioWorklet],
   );
 
-  const stopAll = useCallback(() => {
+  const stopAll = useCallback(async () => {
     isInitialized.current = false;
     isProcessing.current = false;
     setIsPlaying(false);
@@ -300,7 +300,7 @@ export const useSoundPlayer = (props: {
     }
 
     if (audioContext.current) {
-      void audioContext.current
+      await audioContext.current
         .close()
         .then(() => {
           audioContext.current = null;

--- a/packages/react/src/lib/useSoundPlayer.ts
+++ b/packages/react/src/lib/useSoundPlayer.ts
@@ -124,6 +124,7 @@ export const useSoundPlayer = (props: {
     bufferSource.onended = () => {
       if (frequencyDataIntervalId.current) {
         clearInterval(frequencyDataIntervalId.current);
+        frequencyDataIntervalId.current = null;
       }
       setFft(generateEmptyFft());
       bufferSource.disconnect();


### PR DESCRIPTION
PR includes a handful of changes to harden against various potential race conditions.

* Ensures each resource setup/teardown step is awaited before moving onto the next resource, instead of setting up resources in parallel. (parallelism is not possible as explained in the next bullet point)
* Updates the order in which audio player, socket, and microphone are connected and disconnected - this ensures that dependencies are always initialized first, e.g. audio player should be set up before the socket connects, socket should be connected before microphone starts sending audio. Reverse order for teardown.
* Adds guards to make sure that the audio player is connected before the socket tries to send it any audio data to the audio player.
* Adds guards to makes sure the socket is connected before the user tries to send any messages to the assistant backend.
* Adds guards to interrupt the `connect` function to prevent initializing a resource if the connection attempt was canceled. This prevents race conditions like the following scenario: the user could call `connect`, then call `disconnect` before the audio player was set up, but the original `connect` call continues to set up the audio player.
* Add retries to the audio player and microphone stop functions.