### PR TITLE
skip calling onError for audio player errors if call is disconnected

### DIFF
--- a/packages/embed-react/package.json
+++ b/packages/embed-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed-react",
-  "version": "0.2.0-beta.18",
+  "version": "0.2.0-beta.19",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-embed",
-  "version": "0.2.0-beta.18",
+  "version": "0.2.0-beta.19",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-react",
-  "version": "0.2.0-beta.18",
+  "version": "0.2.0-beta.19",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -285,6 +285,9 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
   const player = useSoundPlayer({
     enableAudioWorklet,
     onError: (message, reason) => {
+      if (checkIsDisconnecting() || checkIsDisconnected()) {
+        return;
+      }
       updateError({ type: 'audio_error', reason, message });
     },
     onPlayAudio: (id: string) => {

--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -511,13 +511,6 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
         return;
       }
 
-      if (checkIsDisconnecting()) {
-        console.warn(
-          'Currently disconnecting from a chat. Cannot connect until the previous call is disconnected.',
-        );
-        return;
-      }
-
       updateError(null);
       setStatus({ value: 'connecting' });
       resourceStatusRef.current.socket = 'connecting';
@@ -618,7 +611,6 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
       isConnectingRef.current = false;
     },
     [
-      checkIsDisconnecting,
       checkShouldContinueConnecting,
       client,
       config,


### PR DESCRIPTION
* ignore audio player errors if the call is already disconnected. This is to prevent onError from being called if the backend sends an audio message and then immediately shuts down with an service error - audioContextRef is set to null as part of the disconnect cleanup, so errors that result from that can be safely ignored.
* also removing the disconnecting check when connect is called. I need to do a bit more digging into this issue but want to get this out to unblock us in the immediate term.