### PR TITLE
Publish packages on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
               elif [[ ${GITHUB_REF} == *beta* ]]; then
                 npm publish --access public --tag beta
               else
-                npm publish --access public
+                npm publish --access public --tag latest
               fi
               popd
             done


### PR DESCRIPTION
After this, if you push a tag to the repo it will attempt to publish whatever versions are defined in the package.jsons of the various packages.

Adapted from the [ci publish workflow](https://github.com/humeai/hume-typescript-sdk/blob/e0eb81b6eaa7dd0233c92c51155d9139e863bb50/.github/workflows/ci.yml#L52) in hume-typescript-sdk