### PR TITLE
Bump react SDK version to 0.3.0-beta.2

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-react",
-  "version": "0.3.0-beta.1",
+  "version": "0.3.0-beta.2",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
## Summary
- Bumps `@humeai/voice-react` version to `0.3.0-beta.2`
- Includes `hume` TypeScript SDK `0.15.14` bump from #419