### PR TITLE
fix: only interrupt playback on user_interruption, not user_message

### DIFF
--- a/packages/react/src/lib/VoiceProvider.tsx
+++ b/packages/react/src/lib/VoiceProvider.tsx
@@ -147,9 +147,7 @@ export type VoiceProviderProps = PropsWithChildren<{
   onAudioReceived?: (audioOutputMessage: AudioOutputMessage) => void;
   onAudioStart?: (clipId: string) => void;
   onAudioEnd?: (clipId: string) => void;
-  onInterruption?: (
-    message: UserTranscriptMessage | UserInterruptionMessage,
-  ) => void;
+  onInterruption?: (message: UserInterruptionMessage) => void;
   /**
    * @default true
    * @description Clear messages when the voice is disconnected.
@@ -196,7 +194,9 @@ export const useMicFft = (): FftSnapshot => {
 export const useCallDurationTimestamp = (): string | null => {
   const ctx = useContext(StoresContext);
   if (!ctx) {
-    throw new Error('useCallDurationTimestamp must be used within a VoiceProvider');
+    throw new Error(
+      'useCallDurationTimestamp must be used within a VoiceProvider',
+    );
   }
   return useSyncExternalStore(
     ctx.callDurationStore.subscribe,
@@ -327,8 +327,13 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
     createSessionSettingsMessage,
     clearMessages: clearMessageStore,
   } = messageStore;
-  const { addToQueue: playerAddToQueue, clearQueue: playerClearQueue, stopAll: playerStopAll } = player;
-  const { addToStore: toolStatusAddToStore, clearStore: toolStatusClearStore } = toolStatus;
+  const {
+    addToQueue: playerAddToQueue,
+    clearQueue: playerClearQueue,
+    stopAll: playerStopAll,
+  } = player;
+  const { addToStore: toolStatusAddToStore, clearStore: toolStatusClearStore } =
+    toolStatus;
   const playerIsPlayingRef = useLatestRef(player.isPlaying);
 
   const { getStream, stopStream } = useMicrophoneStream();
@@ -352,10 +357,7 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
 
         messageStoreOnMessage(message);
 
-        if (
-          message.type === 'user_interruption' ||
-          message.type === 'user_message'
-        ) {
+        if (message.type === 'user_interruption') {
           if (playerIsPlayingRef.current) {
             onInterruption.current(message);
           }
@@ -450,7 +452,14 @@ export const VoiceProvider: FC<VoiceProviderProps> = ({
           onClose.current?.(event);
         }
       },
-      [clearMessagesOnDisconnect, createDisconnectMessage, clearMessageStore, playerStopAll, stopTimer, toolStatusClearStore],
+      [
+        clearMessagesOnDisconnect,
+        createDisconnectMessage,
+        clearMessageStore,
+        playerStopAll,
+        stopTimer,
+        toolStatusClearStore,
+      ],
     ),
     onToolCall: props.onToolCall,
   });


### PR DESCRIPTION
## Summary

The SDK cleared audio playback on every `user_message`, including interim transcripts. This was intentional: it let us act on the earliest possible signal so interruptions felt snappy.

We've since introduced configurability for the interruption window, but that only affects server-side interruption detection (when a `user_interruption` message is sent). Interim `user_message` transcripts are emitted independently of that window, so clearing playback on them meant interruption timing ignored the config's `min_interruption_ms`.

The fix is to no longer use `user_message` as a signal for interruption, so that interruption sensitivity configuration is respected. A side effect of the old behavior was that the tail of an assistant turn could be cut off when a user started speaking just as it ended; that no longer happens.

### Changes

- Clear playback only on `user_interruption`, which the server already gates by `min_interruption_ms`. Interruption timing is now governed entirely by that config.
- Narrow `onInterruption` to `UserInterruptionMessage`, since it no longer fires on `user_message`.

### For consumers

If you use the `onInterruption` callback, it now fires only on genuine interruptions, not on every transcribed user message. To react to user transcripts, use `onMessage` and filter for `user_message`. To tune how quickly interruptions trigger, configure [`min_interruption_ms`](https://dev.hume.ai/reference/speech-to-speech-evi/configs/create-config#request.body.interruption).