### PR TITLE
Bump voice-react to 0.3.0-beta.5

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@humeai/voice-react",
-  "version": "0.3.0-beta.4",
+  "version": "0.3.0-beta.5",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Releases the tail-clip fix from #438 (`d406b95`) to npm.

## What ships
`@humeai/voice-react` `0.3.0-beta.4` → `0.3.0-beta.5`, carrying the fix where the SDK treated **interim `user_message` transcripts** as an interruption and cleared the playback queue at the turn boundary — clipping the final ~100ms of the assistant's speech. Playback now only stops on a true `user_interruption` (server-gated by `min_interruption_ms`).

## Context
Resolves the customer-facing tail-clip report (HUME-20016). Investigation confirmed the audio is synthesized and transmitted intact and the player preserves it; the tail-cut on normal conversational turns was this interim-transcript interruption.